### PR TITLE
BAF-1250 gateway crashes when endpoint contains module missing in module paths

### DIFF
--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -420,7 +420,8 @@ std::vector<structures::DeviceIdentification> ExternalConnection::getAllConnecte
 
 		if (statusAggregatorItr == moduleLibrary_.statusAggregators.end())
 		{
-			log::logWarning("Module {} is defined in external-connection endpoint but is not specified in module-paths");
+			log::logWarning("Module {} is defined in external-connection endpoint but is not specified in module-paths",
+							moduleNumber);
 			continue;
 		}
 

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -416,7 +416,15 @@ std::vector<structures::DeviceIdentification> ExternalConnection::getAllConnecte
 	std::vector<structures::DeviceIdentification> devices {};
 	for(const auto &moduleNumber: settings_.modules) {
 		std::list<structures::DeviceIdentification> unique_devices {};
-		const int ret = moduleLibrary_.statusAggregators.at(moduleNumber)->get_unique_devices(unique_devices);
+		auto statusAggregatorItr = moduleLibrary_.statusAggregators.find(moduleNumber);
+
+		if (statusAggregatorItr == moduleLibrary_.statusAggregators.end())
+		{
+			log::logWarning("Module {} is defined in external-connection endpoint but is not specified in module-paths");
+			continue;
+		}
+
+		const int ret = (*statusAggregatorItr).second->get_unique_devices(unique_devices);
 		if(ret <= 0) {
 			log::logWarning("Module {} does not have any connected devices", moduleNumber);
 			continue;

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <ranges>
 
 
 
@@ -107,6 +108,19 @@ bool SettingsParser::areSettingsCorrect() const {
 		std::cerr << "Vehicle name (" << settings_->vehicleName << ") is not valid." << std::endl;
 		isCorrect = false;
 	}
+
+	std::ranges::any_of(settings_->externalConnectionSettingsList, [&](auto& externalConnectionSettings){
+		return std::ranges::any_of(externalConnectionSettings.modules, [&](auto const& externalModuleId) {
+			bool isMissing = !settings_->modulePaths.contains(externalModuleId);
+			if (isMissing)
+			{
+				std::cerr << "Module " << externalModuleId <<
+				" is defined in external-connection endpoint modules but is not specified in module-paths" << std::endl;
+				isCorrect = false;
+			}
+			return isMissing;
+		});
+	});
 
 	return isCorrect;
 }

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -109,14 +109,13 @@ bool SettingsParser::areSettingsCorrect() const {
 		isCorrect = false;
 	}
 
-	std::ranges::any_of(settings_->externalConnectionSettingsList, [&](auto& externalConnectionSettings){
+	isCorrect &= !std::ranges::any_of(settings_->externalConnectionSettingsList, [&](auto& externalConnectionSettings){
 		return std::ranges::any_of(externalConnectionSettings.modules, [&](auto const& externalModuleId) {
 			bool isMissing = !settings_->modulePaths.contains(externalModuleId);
 			if (isMissing)
 			{
 				std::cerr << "Module " << externalModuleId <<
 				" is defined in external-connection endpoint modules but is not specified in module-paths" << std::endl;
-				isCorrect = false;
 			}
 			return isMissing;
 		});

--- a/test/source/SettingsParserTests.cpp
+++ b/test/source/SettingsParserTests.cpp
@@ -185,3 +185,21 @@ TEST_F(SettingsParserTests, InvalidProtocol){
 	EXPECT_TRUE(result);
 	EXPECT_TRUE(settingsParser.getSettings()->externalConnectionSettingsList.empty());
 }
+
+/**
+ * @brief Test if modules specified in endpoint missing in module-paths are handled correctly
+ */
+TEST_F(SettingsParserTests, MissingModules){
+	testing_utils::ConfigMock::Config config {};
+	config.module_paths = { {1, "/path/to/lib1.so"}, {2, "/path/to/lib2.so"}, {3, "/path/to/lib3.so"} };
+	config.external_connection.endpoint.modules = { 1, 2, 3, 4};
+
+	bool failed = false;
+	try {
+		parseConfig(config);
+	}catch (std::invalid_argument &e){
+		EXPECT_STREQ(e.what(), "Arguments are not correct.");
+		failed = true;
+	}
+	EXPECT_TRUE(failed);
+}


### PR DESCRIPTION
When there is module in config file defined under external-connection::endpoints that is not defined in global module-paths config, it crashed the module-gateway when it attempted to connect to external server. 

This pull request fixes the crash and prevents start of gateway with incorrect configuration file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of external device connection lookups with safer error handling that gracefully manages missing modules
  * Added configuration validation to ensure all modules referenced in connection endpoints are properly defined

* **Tests**
  * Added test case to verify proper error detection when configuration contains undefined module references

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->