### PR TITLE
BAF-1256: Add QUIC unidirectional stream support and integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build
+
+Requires an external CMake library (`CMLIB_DIR`):
+
+```bash
+# Standard build
+mkdir -p _build && cd _build
+cmake ../ -DCMLIB_DIR=</absolute/path/to/cmakelib>
+make
+
+# Build with tests — must use clang++-17 (gcc causes AddressSanitizer crashes)
+mkdir -p _build_tests && cd _build_tests
+cmake ../ -DCMLIB_DIR=</absolute/path/to/cmakelib> -DBRINGAUTO_TESTS=ON -DCMAKE_CXX_COMPILER=clang++-17
+make
+```
+
+Key CMake options:
+- `BRINGAUTO_TESTS` — enable tests (requires clang++-17)
+- `BRINGAUTO_INSTALL` — enable install target
+- `BRINGAUTO_PACKAGE` — enable packaging (forces INSTALL=ON)
+- `BRINGAUTO_SYSTEM_DEP` — use system deps instead of fetching
+- `BRINGAUTO_MODULE_GATEWAY_MINIMUM_LOGGER_VERBOSITY` — compile-time log level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+
+## Tests
+
+```bash
+# Run all tests
+cd _build_tests && ctest
+
+# Run a specific test binary directly (e.g. for verbose output)
+cd _build_tests && ./test/ModuleHandlerTests
+```
+
+Tests use port 8888 for the internal server — it must be free when running `InternalServerTests`.
+
+## Run
+
+```bash
+./module-gateway-app --config-path=../resources/config/default.json
+# Optional: --port=<unsigned short>  overrides the internal server port
+```
+
+## Architecture
+
+The gateway bridges internal device clients with external servers. Three main components cooperate via `AtomicQueue`-based message passing:
+
+```
+Internal Client ──► Internal Server ──► [fromInternalQueue] ──► Module Handler
+                                                                       │
+                                                              Module Libraries &
+                                                              Status Aggregators
+                                                                       │
+                ◄── Internal Client ◄── [toInternalQueue] ◄───────────┤
+                                                                       │
+                External Client ◄────── [toExternalQueue] ◄───────────┘
+                      │
+              Error Aggregator
+                      │
+              External Server (MQTT / QUIC / Dummy)
+```
+
+### Internal Server (`internal_server/`)
+Accepts TCP connections from internal clients (devices). Messages are length-prefixed (4-byte little-endian). Forwards device messages to Module Handler; returns responses to the originating client.
+
+### Module Handler (`modules/`)
+The processing core. Loads module shared libraries via `library_loader.hpp`, manages a `StatusAggregator` per device, and routes messages between Internal Server and External Client. Supports local execution (`ModuleManagerLibraryHandlerLocal`) and async shared-memory execution (`ModuleManagerLibraryHandlerAsync`).
+
+### External Client (`external_client/`)
+Manages connections to one or more external server endpoints. Handles reconnection with backoff via `ReconnectQueueItem`. Uses `ErrorAggregator` to buffer messages that failed to deliver. Protocol is abstracted behind `ICommunicationChannel`; concrete implementations: `MqttCommunication`, `QuicCommunication`, `DummyCommunication`.
+
+### Settings (`settings/`)
+JSON config is parsed by `SettingsParser` (and `QuicSettingsParser` for QUIC-specific fields) into `Settings`. Configuration examples are in `resources/config/`.
+
+### Key shared structures (`structures/`)
+- `GlobalContext` — holds `boost::asio::io_context` and `shared_ptr<Settings>`, passed everywhere
+- `AtomicQueue<T>` — thread-safe queue used for all inter-component communication
+- `DeviceIdentification` — unique key for a device (module + device type + device role + device name + priority)
+
+## Language & Conventions
+
+- C++23, compiled with `-Wall -Wextra -Wpedantic`
+- AddressSanitizer + UBSan + LeakSanitizer are enabled in Debug/Test builds
+- Headers live in `include/bringauto/`, implementations mirror that path under `source/bringauto/`
+- Protobuf for serialization; Boost ASIO for async I/O; nlohmann-json for config parsing

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -177,10 +177,6 @@ private:
 
 	std::shared_ptr <structures::AtomicQueue<structures::ReconnectQueueItem>>
 	reconnectQueue_ {};
-	/// Name of the vehicle
-	std::string vehicleName_ {};
-	/// Name of the company
-	std::string company_ {};
 };
 
 }

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -79,6 +79,14 @@ namespace bringauto::external_client::connection::communication {
 		void closeConnection() override;
 
 	private:
+		/// Directionality of QUIC streams created or accepted by this connection
+		enum class StreamMode {
+			/// Stream can only send data in one direction
+			Unidirectional,
+			/// Stream supports bidirectional send and receive
+			Bidirectional
+		};
+
 		/// Pointer to the MsQuic API function table
 		const QUIC_API_TABLE *quic_{nullptr};
 		/// QUIC registration handle associated with the application
@@ -98,6 +106,8 @@ namespace bringauto::external_client::connection::communication {
 		std::filesystem::path keyFile_;
 		/// Path to the CA certificate file
 		std::filesystem::path caFile_;
+
+		StreamMode streamMode_{StreamMode::Bidirectional};
 
 		/// Atomic state of the connection used for synchronization across threads
 		std::atomic<ConnectionState> connectionState_{ConnectionState::NOT_CONNECTED};
@@ -319,21 +329,40 @@ namespace bringauto::external_client::connection::communication {
 		/**
 		 * @brief Retrieves a protocol setting value as a plain string.
 		 *
-		 * Extracts a value from ExternalConnectionSettings::protocolSettings and
-		 * transparently handles values stored as JSON-encoded strings.
+		 * Looks up a value in ExternalConnectionSettings::protocolSettings and returns
+		 * it as a plain string. If the stored value is a JSON-encoded string, it is
+		 * transparently parsed and unwrapped.
 		 *
-		 * Allows uniform access to protocol settings regardless of whether
-		 * they were stored as plain strings or JSON-serialized values.
+		 * If the key does not exist or the value cannot be parsed as valid JSON,
+		 * the provided default value is returned and a warning is logged.
+		 *
+		 * This allows uniform access to protocol settings regardless of whether
+		 * they are stored as plain strings or JSON-serialized strings.
 		 *
 		 * @param settings External connection settings containing protocolSettings.
 		 * @param key Key identifying the protocol setting.
+		 * @param defaultValue Value returned if the key is missing or invalid.
 		 * @return Plain string value suitable for direct use (e.g. file paths).
-		 *
-		 * @throws std::out_of_range if the key is not present in protocolSettings.
 		 */
 		static std::string getProtocolSettingsString(
 			const structures::ExternalConnectionSettings &settings,
-			std::string_view key
+			std::string_view key,
+			std::string defaultValue = {}
 		);
+
+		/**
+		 * @brief Parses QUIC stream mode from protocol settings.
+		 *
+		 * Reads the stream mode from the external connection settings and determines
+		 * whether QUIC streams should be unidirectional or bidirectional.
+		 *
+		 * Supported values:
+		 *  - "unidirectional", "unidir" → Unidirectional streams
+		 *  - any other value or missing setting → Bidirectional streams (default)
+		 *
+		 * @param settings External connection settings containing QUIC protocol options
+		 * @return StreamMode Parsed stream mode (defaults to Bidirectional)
+		 */
+		static StreamMode parseStreamMode(const structures::ExternalConnectionSettings &settings);
 	};
 }

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -81,7 +81,12 @@ namespace bringauto::external_client::connection::communication {
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {
-			/// Stream can only send data in one direction
+			/// Stream can only send data in one direction.
+			/// In this mode each sendMessage() call opens a new outbound stream that is
+			/// immediately closed after the send (START | FIN flags). The peer opens
+			/// separate streams in the opposite direction for responses. Many short-lived
+			/// streams are created over the connection lifetime, but QUIC stream creation
+			/// is lightweight and has no significant impact on performance.
 			Unidirectional,
 			/// Stream supports bidirectional send and receive
 			Bidirectional

--- a/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
+++ b/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <filesystem>
-#include <functional>
 
 
 
@@ -51,7 +50,8 @@ public:
 	 * @param device_type device type
 	 * @return OK if the new status should be aggregated, NOT_OK otherwise
 	 */
-	virtual int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const = 0;
+	virtual int sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                                unsigned int device_type) const = 0;
 
 	/**
 	 * @brief After executing the respective module function, an error might be thrown when allocating the buffer.

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
@@ -17,7 +17,7 @@ namespace bringauto::modules {
  */
 class ModuleManagerLibraryHandlerAsync : public IModuleManagerLibraryHandler {
 public:
-	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath);
+	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, int moduleNumber);
 
 	~ModuleManagerLibraryHandlerAsync() override;
 
@@ -37,7 +37,8 @@ public:
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
+	int	sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                        unsigned int device_type) const override;
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
@@ -98,7 +99,7 @@ private:
 	/// Process of the module binary
 	boost::process::child moduleBinaryProcess_ {};
 	/// TODO find a way to not need this
-	std::mutex tmpMutex_ {};
+	mutable std::mutex tmpMutex_ {};
 };
 
 }

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
@@ -24,7 +24,8 @@ public:
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
+	int	sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                        unsigned int device_type) const override;
 
 	int generateCommand(Buffer &generated_command, const Buffer &new_status,
 						const Buffer &current_status, const Buffer &current_command,
@@ -35,7 +36,7 @@ public:
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
-	 * 
+	 *
 	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
 	 */
 	int	aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
@@ -43,7 +44,7 @@ public:
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
-	 * 
+	 *
 	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
 	 */
 	int generateFirstCommand(Buffer &default_command, unsigned int device_type) override;

--- a/include/bringauto/settings/Constants.hpp
+++ b/include/bringauto/settings/Constants.hpp
@@ -211,6 +211,7 @@ public:
 	inline static constexpr std::string_view CLIENT_CERT { "client-cert" };
 	inline static constexpr std::string_view CLIENT_KEY { "client-key" };
 	inline static constexpr std::string_view ALPN { "alpn" };
+	inline static constexpr std::string_view STREAM_MODE { "stream-mode" };
 
 	inline static constexpr std::string_view MODULES { "modules" };
 	inline static constexpr std::string_view AERON_CONNECTION { "aeron:ipc"};

--- a/resources/config/quic_example.json
+++ b/resources/config/quic_example.json
@@ -27,7 +27,9 @@
           "client-cert" : "build/certs/client.pem",
           "client-key" : "build/certs/client-key.pem",
 	      "alpn" : "sample",
-          "DisconnectTimeoutMs" : 800
+          "stream-mode": "unidirectional",
+          "DisconnectTimeoutMs" : 800,
+          "PeerUnidiStreamCount" : 100
         },
         "modules": [1,2,3]
       }

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -12,7 +12,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 
-
 namespace bringauto::external_client {
 
 namespace ip = InternalProtocol;

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -147,7 +147,9 @@ int ExternalConnection::initializeConnection(const std::vector<structures::Devic
 int ExternalConnection::connectMessageHandle(const std::vector<structures::DeviceIdentification> &devices) {
 	generateSessionId();
 
-	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_, company_, vehicleName_,
+	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_,
+																				   context_->settings->company,
+																				   context_->settings->vehicleName,
 																				   devices);
 	if(not communicationChannel_->sendMessage(&connectMessage)){
 		log::logError("Communication client couldn't send any message");

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -20,7 +20,8 @@ namespace bringauto::external_client::connection::communication {
 		                                                                       settings::Constants::CLIENT_KEY)),
 	                                                                       caFile_(getProtocolSettingsString(
 		                                                                       settings,
-		                                                                       settings::Constants::CA_FILE)) {
+		                                                                       settings::Constants::CA_FILE)),
+	                                                                       streamMode_(parseStreamMode(settings)) {
 		alpnBuffer_.Buffer = reinterpret_cast<uint8_t *>(alpn_.data());
 		alpnBuffer_.Length = static_cast<uint32_t>(alpn_.size());
 
@@ -62,7 +63,7 @@ namespace bringauto::external_client::connection::communication {
 		);
 
 		if (QUIC_FAILED(status)) {
-			settings::Logger::logError("ConnectionOpen failed (status=0x{:x})", status);
+			settings::Logger::logError("ConnectionStart failed (status=0x{:x})", status);
 			return;
 		}
 
@@ -88,15 +89,29 @@ namespace bringauto::external_client::connection::communication {
 	std::shared_ptr<ExternalProtocol::ExternalServer> QuicCommunication::receiveMessage() {
 		std::unique_lock lock(inboundMutex_);
 
+		// Wait for a message or transition out of allowed states
+		// Explicitly allow waiting during CONNECTING, CLOSING, and CONNECTED states
+		// This whitelist approach is safe if new states are added in the future
 		if (!inboundCv_.wait_for(
 			lock,
 			settings::receive_message_timeout,
-			[this] { return !inboundQueue_.empty() || connectionState_.load() != ConnectionState::CONNECTED; }
+			[this] {
+				auto state = connectionState_.load();
+				return !inboundQueue_.empty() ||
+				       (state != ConnectionState::CONNECTING &&
+				        state != ConnectionState::CLOSING &&
+				        state != ConnectionState::CONNECTED);
+			}
 		)) {
 			return nullptr;
 		}
 
-		if (connectionState_.load() != ConnectionState::CONNECTED || inboundQueue_.empty()) {
+		// Check if we stopped waiting due to invalid state or empty queue
+		auto state = connectionState_.load();
+		if ((state != ConnectionState::CONNECTING &&
+		     state != ConnectionState::CLOSING &&
+		     state != ConnectionState::CONNECTED) ||
+		    inboundQueue_.empty()) {
 			return nullptr;
 		}
 
@@ -230,7 +245,13 @@ namespace bringauto::external_client::connection::communication {
 
 	void QuicCommunication::sendViaQuicStream(const ExternalProtocol::ExternalClient& message) {
 		HQUIC stream{nullptr};
-		if (QUIC_FAILED(quic_->StreamOpen(connection_, QUIC_STREAM_OPEN_FLAG_NONE, streamCallback, this, &stream))) {
+
+		QUIC_STREAM_OPEN_FLAGS flags = streamMode_ == StreamMode::Unidirectional
+			                               ? QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL
+			                               : QUIC_STREAM_OPEN_FLAG_NONE;
+
+		if (QUIC_FAILED(
+			quic_->StreamOpen(connection_, flags, streamCallback, this, &stream))) {
 			settings::Logger::logError("[quic] StreamOpen failed");
 			return;
 		}
@@ -271,7 +292,7 @@ namespace bringauto::external_client::connection::communication {
 		settings::Logger::logDebug("[quic] [stream {}] Message sent", streamId ? *streamId : 0);
 	}
 
-	QUIC_STATUS QUIC_API QuicCommunication::connectionCallback(HQUIC connection, void *context, // NOSONAR - void* required by QUIC_CONNECTION_CALLBACK C API
+	QUIC_STATUS QUIC_API QuicCommunication::connectionCallback(HQUIC connection, void *context,
 	                                                           QUIC_CONNECTION_EVENT *event) {
 		auto *self = static_cast<QuicCommunication *>(context);
 
@@ -287,6 +308,23 @@ namespace bringauto::external_client::connection::communication {
 					self->senderThread_ = std::jthread(&QuicCommunication::senderLoop, self);
 					self->outboundCv_.notify_all();
 				}
+				break;
+			}
+
+			/// Fired when peer open new stream on connection, stream handler need to be def
+			case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
+				auto streamId = self->getStreamId(event->PEER_STREAM_STARTED.Stream);
+
+				settings::Logger::logDebug(
+					"[quic] [stream {}] Peer stream started",
+					streamId.value_or(0)
+				);
+
+				self->quic_->SetCallbackHandler(event->PEER_STREAM_STARTED.Stream,
+				                                reinterpret_cast<void *>(streamCallback), // NOSONAR - MsQuic C API requires passing function pointer as void*
+				                                context);
+
+				self->quic_->StreamReceiveSetEnabled(event->PEER_STREAM_STARTED.Stream, TRUE);
 				break;
 			}
 
@@ -325,7 +363,7 @@ namespace bringauto::external_client::connection::communication {
 		return QUIC_STATUS_SUCCESS;
 	}
 
-	QUIC_STATUS QUIC_API QuicCommunication::streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) { // NOSONAR - void* required by QUIC_STREAM_CALLBACK C API
+	QUIC_STATUS QUIC_API QuicCommunication::streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) {
 		auto *self = static_cast<QuicCommunication *>(context);
 		auto streamId = self->getStreamId(stream);
 
@@ -487,16 +525,39 @@ namespace bringauto::external_client::connection::communication {
 
 	std::string QuicCommunication::getProtocolSettingsString(
 		const structures::ExternalConnectionSettings &settings,
-		std::string_view key
+		std::string_view key,
+		std::string defaultValue
 	) {
-		const auto &raw = settings.protocolSettings.at(std::string(key));
-
-		if (nlohmann::json::accept(raw)) {
-			auto j = nlohmann::json::parse(raw);
-			if (j.is_string()) {
-				return j.get<std::string>();
-			}
+		const auto it = settings.protocolSettings.find(std::string(key));
+		if (it == settings.protocolSettings.end()) {
+			settings::Logger::logWarning("[quic] Protocol setting '{}' not found, using default", key);
+			return defaultValue;
 		}
-		return raw;
+
+		const auto &raw = it->second;
+
+		try {
+			if (nlohmann::json::accept(raw)) {
+				auto j = nlohmann::json::parse(raw);
+				if (j.is_string()) {
+					return j.get<std::string>();
+				}
+			}
+			return raw;
+		} catch (const nlohmann::json::exception &) {
+			settings::Logger::logWarning("[quic] Protocol setting '{}' contains invalid JSON, using default", key);
+			return defaultValue;
+		}
+	}
+
+	QuicCommunication::StreamMode QuicCommunication::parseStreamMode(
+		const structures::ExternalConnectionSettings &settings
+	) {
+		const std::string mode = getProtocolSettingsString(settings, settings::Constants::STREAM_MODE);
+
+		if (mode == "unidirectional" || mode == "unidir")
+			return StreamMode::Unidirectional;
+
+		return StreamMode::Bidirectional;
 	}
 }

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -29,31 +29,38 @@ static fp_async::ModuleFunctionExecutor aeronClient {
 	fp_async::moduleFunctionList
 };
 
-ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath) :
+ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, int moduleNumber) :
 		moduleBinaryPath_ { moduleBinaryPath } {
-	aeronClient.connect();
+	aeronClient.connect(moduleNumber);
 }
 
 ModuleManagerLibraryHandlerAsync::~ModuleManagerLibraryHandlerAsync() {
+	if (!moduleBinaryProcess_.valid()) {
+		return;
+	}
+	::kill(moduleBinaryProcess_.id(), SIGTERM);
 	try {
-		if (moduleBinaryProcess_.valid()) {
-			::kill(moduleBinaryProcess_.id(), SIGTERM);
-			moduleBinaryProcess_.wait();
-		}
-	} catch (...) { /* destructor must not throw */ }
+		moduleBinaryProcess_.wait();
+	} catch (const boost::process::process_error&) {
+		// wait() failed — process already reaped or unreachable. Nothing to do.
+	}
 }
 
 void ModuleManagerLibraryHandlerAsync::loadLibrary(const std::filesystem::path &path) {
-	moduleBinaryProcess_ = boost::process::child { moduleBinaryPath_.string(), "-m", path.string() };
+	try {
+		moduleBinaryProcess_ = boost::process::child { moduleBinaryPath_.string(), "-m", path.string() };
+	} catch (const boost::process::process_error& e) {
+		throw ModuleBinaryException { "Failed to start module binary " + moduleBinaryPath_.string() + ": " + e.what() };
+	}
 	if (!moduleBinaryProcess_.valid()) {
 		throw ModuleBinaryException { "Failed to start module binary " + moduleBinaryPath_.string() };
 	}
 	const auto deadline = std::chrono::steady_clock::now() + settings::AeronClientConstants::aeron_client_startup_timeout;
-	while(!aeronClient.callFunc(fp_async::getModuleNumberAsync).has_value()) {
-		if(!moduleBinaryProcess_.running()) {
+	while (!aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::getModuleNumberAsync).has_value()) {
+		if (!moduleBinaryProcess_.running()) {
 			throw ModuleBinaryException { "Module binary terminated before becoming ready: " + moduleBinaryPath_.string() };
 		}
-		if(std::chrono::steady_clock::now() >= deadline) {
+		if (std::chrono::steady_clock::now() >= deadline) {
 			throw ModuleBinaryException { "Module binary did not respond within startup timeout: " + moduleBinaryPath_.string() };
 		}
 		std::this_thread::sleep_for(settings::AeronClientConstants::module_binary_poll_interval);
@@ -72,8 +79,9 @@ int ModuleManagerLibraryHandlerAsync::isDeviceTypeSupported(unsigned int device_
 int ModuleManagerLibraryHandlerAsync::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
 													 	  unsigned int device_type) const {
-	ConvertibleBuffer current_status_raw_buffer;
-	ConvertibleBuffer new_status_raw_buffer;
+	std::lock_guard lock { tmpMutex_ };
+	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_status_raw_buffer;
+	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
 		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -76,7 +76,8 @@ int ModuleManagerLibraryHandlerLocal::isDeviceTypeSupported(unsigned int device_
 
 int ModuleManagerLibraryHandlerLocal::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
-														  unsigned int device_type) const {
+														  unsigned int device_type)
+const {
 	struct ::buffer current_status_raw_buffer {};
 	struct ::buffer new_status_raw_buffer {};
 

--- a/source/bringauto/settings/QuicSettingsParser.cpp
+++ b/source/bringauto/settings/QuicSettingsParser.cpp
@@ -29,6 +29,12 @@ namespace bringauto::settings {
 			quic.IsSet.DisconnectTimeoutMs = TRUE;
 		}
 
+		if (auto value = getOptionalUint(settings, "PeerUnidiStreamCount"); value.has_value()) {
+			settings::Logger::logDebug("[quic] [settings] PeerUnidiStreamCount settings loaded");
+			quic.PeerUnidiStreamCount = *value;
+			quic.IsSet.PeerUnidiStreamCount = TRUE;
+		}
+
 		return quic;
 	}
 

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -118,7 +118,6 @@ bool SettingsParser::areSettingsCorrect() const {
 			}
 		}
 	}
-
 	return isCorrect;
 }
 
@@ -174,7 +173,6 @@ void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
 	if(file.contains(std::string(Constants::MODULE_BINARY_PATH))) {
 		settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 	}
-	settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 }
 
 void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) const {
@@ -210,6 +208,10 @@ void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) 
 		
 		if(!settingsName.empty() && endpoint.find(settingsName) != endpoint.end()) {
 			for(auto &[key, val]: endpoint[settingsName].items()) {
+				if (val.is_string()) {
+					externalConnectionSettings.protocolSettings[key] = val.get<std::string>();
+					continue;
+				}
 				externalConnectionSettings.protocolSettings[key] = to_string(val);
 			}
 		}
@@ -262,7 +264,11 @@ std::string SettingsParser::serializeToJson() const {
 				break;
 		}
 		for(const auto &[key, val]: endpoint.protocolSettings) {
-			endpointAsJson[settingsName][key] = nlohmann::json::parse(val);
+			if (nlohmann::json::accept(val)) {
+				endpointAsJson[settingsName][key] = nlohmann::json::parse(val);
+				continue;
+			}
+			endpointAsJson[settingsName][key] = val;
 		}
 		endpoints.push_back(endpointAsJson);
 	}

--- a/source/bringauto/structures/ModuleLibrary.cpp
+++ b/source/bringauto/structures/ModuleLibrary.cpp
@@ -19,7 +19,7 @@ void ModuleLibrary::loadLibraries(const std::unordered_map<int, std::filesystem:
 		if (moduleBinaryPath.empty()) {
 			handler = std::make_shared<modules::ModuleManagerLibraryHandlerLocal>();
 		} else {
-			handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath);
+			handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath, key);
 		}
 		handler->loadLibrary(path);
 		if (handler->getModuleNumber() != key)

--- a/test/include/testing_utils/ConfigMock.hpp
+++ b/test/include/testing_utils/ConfigMock.hpp
@@ -50,15 +50,15 @@ public:
 				int port { 1883 };
 				
 				std::unordered_map<std::string, std::string> mqtt_settings {
-					{ "ssl", "\"false\"" },
-					{ "ca-file", "\"ca.pem\"" },
-					{ "client-cert", "\"client.pem\"" },
-					{ "client", "\"key.pem\"" }
+					{ "ssl", "false" },
+					{ "ca-file", "ca.pem" },
+					{ "client-cert", "client.pem" },
+					{ "client", "key.pem" }
 				};
 				std::string mqttSettingsToString() const {
 					std::string result = "";
 					for (auto [key, value] : mqtt_settings) {
-						result += std::format("\"{}\": {},\n", key, value);
+						result += std::format("\"{}\": \"{}\",\n", key, value);
 					}
 					if (!result.empty()) {
 						result.pop_back();


### PR DESCRIPTION
## Summary

- Added `QuicCommunication` with unidirectional stream support and configurable `stream-mode` (`unidirectional`/`bidirectional`)
- Wired QUIC into `ExternalClient`, `ExternalConnection`, and `SettingsParser`; added `PeerUnidiStreamCount` parsing in `QuicSettingsParser`
- Simplified `ModuleManagerLibraryHandlerAsync` and fixed wrong mutex used in `sendStatusCondition`