### PR TITLE
Fix constructBuffer crash and add QUIC unidirectional stream support

### DIFF
--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -211,6 +211,9 @@ Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::size_t size) {
 }
 
 Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::span<const uint8_t> data) {
+	if (data.empty()) {
+		return constructBuffer();
+	}
 	auto buff = constructBuffer(data.size());
 	std::memcpy(buff.getStructBuffer().data, data.data(), data.size());
 	return buff;


### PR DESCRIPTION
## Summary

- Fixed crash in `constructBuffer` when called with an empty span in the async module handler
- Fixed wrong mutex used in `sendStatusCondition`
- Added unidirectional stream support to `QuicCommunication` with proper peer stream handling
- Wired QUIC unidirectional mode through `ExternalClient`, `ExternalConnection`, and `SettingsParser`
- Added `PeerUnidiStreamCount` parsing to `QuicSettingsParser` and updated example config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added QUIC protocol support for external connections with configurable TLS certificates and stream settings.
  * New library loader mechanism for improved module loading.

* **Bug Fixes**
  * Added null-pointer safety check in connection deinitialization.

* **Refactor**
  * Updated module handler interfaces for improved const-correctness and maintainability.
  * Simplified buffer management in module communication.

* **Documentation**
  * Added development guidance documentation for AI-assisted code interaction.
  * Updated configuration documentation with QUIC protocol examples and settings.

* **Chores**
  * Added QUIC library dependency and updated build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->