### PR TITLE
Drain toExternalQueue during initializeConnection and add cancelReceive interface

### DIFF
--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -9,6 +9,7 @@
 
 #include <InternalProtocol.pb.h>
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <unordered_map>

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -50,6 +50,17 @@ private:
 	void startExternalConnectSequence(connection::ExternalConnection &connection);
 
 	/**
+	 * @brief Drain toExternalQueue while a background connect attempt is in progress.
+	 * Feeds arriving statuses through fillErrorAggregator so the aggregate error count
+	 * stays in sync with the module's predictive check in sendStatusCondition.
+	 *
+	 * @param connection connection being initialised
+	 * @param connectDone atomic flag set to true by the background thread on completion
+	 */
+	void drainQueueDuringConnect(connection::ExternalConnection &connection,
+	                             std::atomic<bool> &connectDone);
+
+	/**
 	 * @brief Handle aggregated status messages from a module handler
 	 */
 	void handleAggregatedMessages();

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -11,6 +11,7 @@
 #include <bringauto/structures/DeviceIdentification.hpp>
 #include <bringauto/structures/ReconnectQueueItem.hpp>
 
+#include <mutex>
 #include <string>
 #include <vector>
 #include <thread>
@@ -152,6 +153,13 @@ private:
 	 * Loop is receiving messages from external server and processes them.
 	 */
 	void receivingHandlerLoop();
+
+	/**
+	 * @brief Implementation of fillErrorAggregatorWithNotAckedStatuses without locking.
+	 * Must be called with errorAggregatorsMutex_ already held.
+	 */
+	void fillErrorAggregatorWithNotAckedStatusesImpl();
+
 	/// Indication if receiving loop should be stopped
 	std::atomic<bool> stopReceiving { false };
 	/// Length of the key used for identification
@@ -177,6 +185,8 @@ private:
 	const structures::ExternalConnectionSettings &settings_ {};
 	/// Class handling sent messages - timers, not acknowledged statuses etc.
 	std::unique_ptr <messages::SentMessagesHandler> sentMessagesHandler_ {};
+	/// Mutex guarding errorAggregators_ against concurrent access during the connect sequence
+	std::mutex errorAggregatorsMutex_ {};
 	/// @brief Map of error aggregators, key is module number
 	std::unordered_map<unsigned int, ErrorAggregator> errorAggregators_ {};
 	/// Queue of commands received from external server, commands are processed by aggregator

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -100,6 +100,13 @@ public:
 	void setNotInitialized();
 
 	/**
+	 * @brief Abort an in-progress connection attempt by closing the channel.
+	 * Fires SHUTDOWN_COMPLETE which wakes up any blocked receiveMessage() call.
+	 * Does NOT call fillErrorAggregatorWithNotAckedStatuses — safe to call during shutdown.
+	 */
+	void cancelPendingConnect();
+
+	/**
 	 * @brief Check if module type is supported
 	 *
 	 * @param moduleNum module type number

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -34,6 +34,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override {}  // DummyCommunication always returns nullptr from receiveMessage
+
 private:
 	/// Flag to indicate if the fake connection is established
 	bool isConnected_ { false };

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -34,7 +34,7 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override {}  // DummyCommunication always returns nullptr from receiveMessage
+	void cancelReceive() override { /* receiveMessage() always returns nullptr — nothing to unblock */ }
 
 private:
 	/// Flag to indicate if the fake connection is established

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -47,6 +47,13 @@ public:
 	 */
 	virtual void closeConnection() = 0;
 
+	/**
+	 * @brief Unblock any pending receiveMessage() call immediately.
+	 * Used during shutdown to abort an in-progress connect attempt without
+	 * the full receive_message_timeout delay.
+	 */
+	virtual void cancelReceive() = 0;
+
 protected:
 	/// Instance of the specific settings for the communication channel
 	structures::ExternalConnectionSettings settings_ {};

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,6 +27,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override {}  // MQTT receive cancellation handled by its own timeout
+
 private:
 	void connect();
 

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,7 +27,8 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override { /* MQTT receive cancellation handled by its own timeout */ }
+	// Paho MQTT does not expose a blocking-consumer interrupt; shutdown waits up to receive_message_timeout.
+	void cancelReceive() override {}
 
 private:
 	void connect();

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,7 +27,7 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override {}  // MQTT receive cancellation handled by its own timeout
+	void cancelReceive() override { /* MQTT receive cancellation handled by its own timeout */ }
 
 private:
 	void connect();

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -78,6 +78,8 @@ namespace bringauto::external_client::connection::communication {
 		 */
 		void closeConnection() override;
 
+		void cancelReceive() override;
+
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {
@@ -116,6 +118,9 @@ namespace bringauto::external_client::connection::communication {
 
 		/// Atomic state of the connection used for synchronization across threads
 		std::atomic<ConnectionState> connectionState_{ConnectionState::NOT_CONNECTED};
+
+		/// Set by cancelReceive() to unblock a pending receiveMessage() call immediately
+		std::atomic<bool> cancelReceive_{false};
 
 		/// @name Inbound (peer → this)
 		/// @{

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -188,12 +188,15 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 
 void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
                                               std::atomic<bool> &connectDone) {
-	while (!connectDone.load() && !context_->ioContext.stopped()) {
-		if (connection.getState() == connection::ConnectionState::CONNECTED) {
-			break;  // success path: stop filling to avoid racing with clear_error_aggregator
-		}
+	while (!connectDone.load() && !context_->ioContext.stopped() &&
+	       connection.getState() != connection::ConnectionState::CONNECTED) {
 		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
 			continue;
+		}
+		// Re-check after unblocking: connection may have finished while we were waiting.
+		// Without this, we could pop and feed fillErrorAggregator after clear_error_aggregator already ran.
+		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;
 		}
 		const auto internalMessage = std::move(toExternalQueue_->front());
 		toExternalQueue_->pop();

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -186,6 +186,26 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 	return true;
 }
 
+void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
+                                              std::atomic<bool> &connectDone) {
+	while (!connectDone.load() && !context_->ioContext.stopped()) {
+		if (connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;  // success path: stop filling to avoid racing with clear_error_aggregator
+		}
+		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
+			continue;
+		}
+		const auto internalMessage = std::move(toExternalQueue_->front());
+		toExternalQueue_->pop();
+		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
+		if (connection.isModuleSupported(deviceStatus.device().module())) {
+			connection.fillErrorAggregator(deviceStatus);
+		} else {
+			sendStatus(internalMessage);
+		}
+	}
+}
+
 void ExternalClient::startExternalConnectSequence(connection::ExternalConnection &connection) {
 	settings::Logger::logInfo("Initializing new connection");
 	insideConnectSequence_ = true;
@@ -240,30 +260,16 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	// continue to be fed through fillErrorAggregator. Without this, the
 	// aggregate_error invoke count falls out of sync with the module's predictive
 	// check in sendStatusCondition, causing spurious test failures.
-	std::atomic<bool> connectDone { false };
+	std::atomic connectDone { false };
 	int connectResult = NOT_OK;
 	std::jthread connectThread([&]() {
 		connectResult = connection.initializeConnection(connectedDevices);
-		connectDone.store(true, std::memory_order_release);
+		connectDone.store(true);
 	});
 
-	while (!connectDone.load(std::memory_order_acquire) && not context_->ioContext.stopped()) {
-		if (connection.getState() == connection::ConnectionState::CONNECTED) {
-			break;  // success path: stop filling to avoid racing with clear_error_aggregator
-		}
-		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
-			continue;
-		}
-		const auto internalMessage = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
-		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
-		if (connection.isModuleSupported(deviceStatus.device().module())) {
-			connection.fillErrorAggregator(deviceStatus);
-		} else {
-			sendStatus(internalMessage);
-		}
-	}
-	if (context_->ioContext.stopped() && !connectDone.load(std::memory_order_acquire)) {
+	drainQueueDuringConnect(connection, connectDone);
+
+	if (context_->ioContext.stopped() && !connectDone.load()) {
 		// Interrupt initializeConnection() so the thread can finish promptly.
 		// closeConnection() fires SHUTDOWN_COMPLETE which notifies inboundCv_,
 		// waking any blocked receiveMessage() call.
@@ -271,7 +277,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	}
 	connectThread.join();
 
-	if(connectResult != 0 && not context_->ioContext.stopped()) {
+	if(connectResult != 0 && !context_->ioContext.stopped()) {
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <atomic>
+
 
 namespace bringauto::external_client {
 
@@ -233,7 +235,43 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	}
 	connection.fillErrorAggregatorWithNotAckedStatuses();
 
-	if(connection.initializeConnection(connectedDevices) != 0 && not context_->ioContext.stopped()) {
+	// Run initializeConnection on a background thread so that statuses arriving
+	// during a long connect attempt (e.g. QUIC 5-second receive_message_timeout)
+	// continue to be fed through fillErrorAggregator. Without this, the
+	// aggregate_error invoke count falls out of sync with the module's predictive
+	// check in sendStatusCondition, causing spurious test failures.
+	std::atomic<bool> connectDone { false };
+	int connectResult = NOT_OK;
+	std::jthread connectThread([&]() {
+		connectResult = connection.initializeConnection(connectedDevices);
+		connectDone.store(true, std::memory_order_release);
+	});
+
+	while (!connectDone.load(std::memory_order_acquire) && not context_->ioContext.stopped()) {
+		if (connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;  // success path: stop filling to avoid racing with clear_error_aggregator
+		}
+		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
+			continue;
+		}
+		const auto internalMessage = std::move(toExternalQueue_->front());
+		toExternalQueue_->pop();
+		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
+		if (connection.isModuleSupported(deviceStatus.device().module())) {
+			connection.fillErrorAggregator(deviceStatus);
+		} else {
+			sendStatus(internalMessage);
+		}
+	}
+	if (context_->ioContext.stopped() && !connectDone.load(std::memory_order_acquire)) {
+		// Interrupt initializeConnection() so the thread can finish promptly.
+		// closeConnection() fires SHUTDOWN_COMPLETE which notifies inboundCv_,
+		// waking any blocked receiveMessage() call.
+		connection.cancelPendingConnect();
+	}
+	connectThread.join();
+
+	if(connectResult != 0 && not context_->ioContext.stopped()) {
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -263,6 +263,10 @@ u_int32_t ExternalConnection::getNextStatusCounter() {
 	return ++clientMessageCounter_;
 }
 
+void ExternalConnection::cancelPendingConnect() {
+	communicationChannel_->closeConnection();
+}
+
 void ExternalConnection::deinitializeConnection(bool completeDisconnect = false) {
 	state_.exchange(ConnectionState::NOT_INITIALIZED);
 	clientMessageCounter_ = 0;

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -137,8 +137,11 @@ int ExternalConnection::initializeConnection(const std::vector<structures::Devic
 	}
 	listeningThread = std::jthread(&ExternalConnection::receivingHandlerLoop, this);
 	state_.exchange(ConnectionState::CONNECTED);
-	for(auto &[moduleNum, errorAggregator]: errorAggregators_) {
-		errorAggregator.clear_error_aggregator();
+	{
+		std::lock_guard lock(errorAggregatorsMutex_);
+		for(auto &[moduleNum, errorAggregator]: errorAggregators_) {
+			errorAggregator.clear_error_aggregator();
+		}
 	}
 	log::logInfo("Connect sequence successful. Server {}:{}", settings_.serverIp, settings_.port);
 	return OK;
@@ -182,21 +185,25 @@ int ExternalConnection::statusMessageHandle(const std::vector<structures::Device
 		modules::Buffer errorBuffer {};
 		modules::Buffer statusBuffer {};
 
-		const auto &lastErrorStatusRc = errorAggregators_[deviceModule].get_error(errorBuffer, deviceIdentification);
-		if(lastErrorStatusRc == DEVICE_NOT_REGISTERED) {
-			log::logError("Device is not registered in error aggregator: {} {}",
-				deviceIdentification.getDeviceRole(),
-				deviceIdentification.getDeviceName());
-			return DEVICE_NOT_REGISTERED;
+		{
+			std::lock_guard lock(errorAggregatorsMutex_);
+			const auto &lastErrorStatusRc = errorAggregators_[deviceModule].get_error(errorBuffer, deviceIdentification);
+			if(lastErrorStatusRc == DEVICE_NOT_REGISTERED) {
+				log::logError("Device is not registered in error aggregator: {} {}",
+					deviceIdentification.getDeviceRole(),
+					deviceIdentification.getDeviceName());
+				return DEVICE_NOT_REGISTERED;
+			}
+
+			const int lastStatusRc = errorAggregators_[deviceModule].get_last_status(statusBuffer, deviceIdentification);
+			if(lastStatusRc != OK) {
+				log::logError("Cannot obtain status for device: {} {}",
+					deviceIdentification.getDeviceRole(),
+					deviceIdentification.getDeviceName());
+				return NO_MESSAGE_AVAILABLE;
+			}
 		}
 
-		const int lastStatusRc = errorAggregators_[deviceModule].get_last_status(statusBuffer, deviceIdentification);
-		if(lastStatusRc != OK) {
-			log::logError("Cannot obtain status for device: {} {}",
-				deviceIdentification.getDeviceRole(),
-				deviceIdentification.getDeviceName());
-			return NO_MESSAGE_AVAILABLE;
-		}
 		auto deviceStatus = common_utils::ProtobufUtils::createDeviceStatus(deviceIdentification, statusBuffer);
 		sendStatus(deviceStatus, ExternalProtocol::Status_DeviceState_CONNECTING, errorBuffer);
 	}
@@ -369,7 +376,7 @@ u_int32_t ExternalConnection::getCommandCounter(const ExternalProtocol::Command 
 	return command.messagecounter();
 }
 
-void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
+void ExternalConnection::fillErrorAggregatorWithNotAckedStatusesImpl() {
 	for(const auto &notAckedStatus: sentMessagesHandler_->getNotAckedStatuses()) {
 		const auto &device = notAckedStatus->getDevice();
 
@@ -391,14 +398,20 @@ void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
 	sentMessagesHandler_->clearAll();
 }
 
+void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
+	std::lock_guard lock(errorAggregatorsMutex_);
+	fillErrorAggregatorWithNotAckedStatusesImpl();
+}
+
 void ExternalConnection::fillErrorAggregator(const InternalProtocol::DeviceStatus &deviceStatus) {
 	int moduleNum = deviceStatus.device().module();
+	std::lock_guard lock(errorAggregatorsMutex_);
 	const auto it = errorAggregators_.find(moduleNum);
 	if(it == errorAggregators_.end()) {
 		log::logError("Module with module number {} does no exists", moduleNum);
 		return;
 	}
-	fillErrorAggregatorWithNotAckedStatuses();
+	fillErrorAggregatorWithNotAckedStatusesImpl();
 	const auto &statusData = deviceStatus.statusdata();
 	const auto statusBuffer = moduleLibrary_.moduleLibraryHandlers.at(moduleNum)->constructBuffer(
 		statusData.size());

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -264,6 +264,7 @@ u_int32_t ExternalConnection::getNextStatusCounter() {
 }
 
 void ExternalConnection::cancelPendingConnect() {
+	communicationChannel_->cancelReceive();
 	communicationChannel_->closeConnection();
 }
 

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -38,6 +38,8 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::initializeConnection() {
+		cancelReceive_.store(false, std::memory_order_release);
+
 		settings::Logger::logDebug("[quic] Connecting to server when {}",
 		                           common_utils::EnumUtils::connectionStateToString(connectionState_));
 
@@ -98,6 +100,7 @@ namespace bringauto::external_client::connection::communication {
 			[this] {
 				auto state = connectionState_.load();
 				return !inboundQueue_.empty() ||
+				       cancelReceive_.load(std::memory_order_acquire) ||
 				       (state != ConnectionState::CONNECTING &&
 				        state != ConnectionState::CLOSING &&
 				        state != ConnectionState::CONNECTED);
@@ -194,6 +197,11 @@ namespace bringauto::external_client::connection::communication {
 		quic_->ConnectionShutdown(connection_, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
 
 		/// Asynchronously waiting for QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event, then continue in connectionCallback
+	}
+
+	void QuicCommunication::cancelReceive() {
+		cancelReceive_.store(true, std::memory_order_release);
+		inboundCv_.notify_all();
 	}
 
 	void QuicCommunication::closeConfiguration() {
@@ -334,7 +342,6 @@ namespace bringauto::external_client::connection::communication {
 				settings::Logger::logInfo("[quic] Connection shutdown complete");
 
 				self->connectionState_ = ConnectionState::NOT_CONNECTED;
-				self->inboundCv_.notify_all();
 				self->outboundCv_.notify_all();
 
 				if (self->senderThread_.joinable()) {

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -334,6 +334,7 @@ namespace bringauto::external_client::connection::communication {
 				settings::Logger::logInfo("[quic] Connection shutdown complete");
 
 				self->connectionState_ = ConnectionState::NOT_CONNECTED;
+				self->inboundCv_.notify_all();
 				self->outboundCv_.notify_all();
 
 				if (self->senderThread_.joinable()) {

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -38,7 +38,7 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::initializeConnection() {
-		cancelReceive_.store(false, std::memory_order_release);
+		cancelReceive_.store(false);
 
 		settings::Logger::logDebug("[quic] Connecting to server when {}",
 		                           common_utils::EnumUtils::connectionStateToString(connectionState_));
@@ -100,7 +100,7 @@ namespace bringauto::external_client::connection::communication {
 			[this] {
 				auto state = connectionState_.load();
 				return !inboundQueue_.empty() ||
-				       cancelReceive_.load(std::memory_order_acquire) ||
+				       cancelReceive_.load() ||
 				       (state != ConnectionState::CONNECTING &&
 				        state != ConnectionState::CLOSING &&
 				        state != ConnectionState::CONNECTED);
@@ -200,7 +200,7 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::cancelReceive() {
-		cancelReceive_.store(true, std::memory_order_release);
+		cancelReceive_.store(true);
 		inboundCv_.notify_all();
 	}
 

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -22,6 +22,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override { /* no-op: mock receiveMessage() is controlled via queued messages */ }
+
 	std::string getSessionId() const;
 
 	void setFailOnInitConnection(bool failOnInitConnection);


### PR DESCRIPTION
## Summary

- Run `initializeConnection` on a background thread so statuses arriving during a long connect attempt (e.g. QUIC 5-second receive timeout) continue to be fed through `fillErrorAggregator`, fixing stale `aggregate_error_invoke_count` that caused spurious test failures
- Add `cancelReceive()` as a pure virtual to `ICommunicationChannel` and implement it in `QuicCommunication` via an atomic flag that unblocks `receiveMessage()` immediately on shutdown — avoids waiting the full receive timeout when cancelling an in-progress connect
- No-op overrides added to `MqttCommunication` and `DummyCommunication`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel pending connection attempts, enabling faster shutdown and improved handling of connection failures.
  * Enhanced message queue processing during connection initialization to maintain consistent error tracking and status aggregation.

* **Improvements**
  * Optimized connection sequencing with background initialization for better responsiveness during connection establishment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->