### PR TITLE
Detect external server disconnect and fix ConvertibleBuffer explicit constructor

### DIFF
--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -34,6 +34,8 @@ public:
 
 	void closeConnection() override;
 
+	bool isConnected() const override;
+
 private:
 	/// Flag to indicate if the fake connection is established
 	bool isConnected_ { false };

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -47,6 +47,13 @@ public:
 	 */
 	virtual void closeConnection() = 0;
 
+	/**
+	 * @brief Check if the communication channel is currently connected
+	 *
+	 * @return bool true if connected, false otherwise
+	 */
+	virtual bool isConnected() const = 0;
+
 protected:
 	/// Instance of the specific settings for the communication channel
 	structures::ExternalConnectionSettings settings_ {};

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -74,7 +74,7 @@ private:
 	/// MQTT QOS level. Level 1 assures that message is delivered at least once
 	constexpr static int8_t qos { 1 };
 	/// Mutex to prevent deadlocks when receiving messages
-	std::mutex receiveMessageMutex_ {};
+	mutable std::mutex receiveMessageMutex_ {};
 };
 
 }

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,6 +27,8 @@ public:
 
 	void closeConnection() override;
 
+	bool isConnected() const override;
+
 private:
 	void connect();
 

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -332,7 +332,15 @@ void ExternalConnection::receivingHandlerLoop() {
 			continue;
 		}
 		const auto serverMessage = communicationChannel_->receiveMessage();
-		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
+		if(serverMessage == nullptr) {
+			if(!communicationChannel_->isConnected()) {
+				log::logWarning("Connection to external server lost, triggering reconnect");
+				reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
+				return;
+			}
+			continue;
+		}
+		if(state_.load() == ConnectionState::NOT_CONNECTED) {
 			continue;
 		}
 		if(serverMessage->has_command()) {

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -272,6 +272,7 @@ void ExternalConnection::deinitializeConnection(bool completeDisconnect = false)
 	if(listeningThread.joinable()) {
 		listeningThread.join();
 	}
+	stopReceiving.store(false);
 
 	if(not completeDisconnect) {
 		fillErrorAggregatorWithNotAckedStatuses();

--- a/source/bringauto/external_client/connection/communication/DummyCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/DummyCommunication.cpp
@@ -33,6 +33,10 @@ std::shared_ptr<ExternalProtocol::ExternalServer> DummyCommunication::receiveMes
     return nullptr;
 }
 
+bool DummyCommunication::isConnected() const {
+    return isConnected_;
+}
+
 void DummyCommunication::closeConnection() {
     settings::Logger::logDebug("Closing DummyCommunication connection");
     isConnected_ = false;

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -120,6 +120,7 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 }
 
 bool MqttCommunication::isConnected() const {
+	std::lock_guard<std::mutex> lock(receiveMessageMutex_);
 	return client_ != nullptr && client_->is_connected();
 }
 

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -108,6 +108,10 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 	}
 
 	if(!msg) {
+		// NOTE: TOCTOU — between returning nullptr here and the caller's subsequent
+		// isConnected() check, MQTT auto-reconnect may fire. A spurious reconnect
+		// notification is possible but harmless; the caller will simply re-establish
+		// the connection.
 		return nullptr;
 	}
 

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -119,6 +119,10 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 	return ptr;
 }
 
+bool MqttCommunication::isConnected() const {
+	return client_ != nullptr && client_->is_connected();
+}
+
 void MqttCommunication::closeConnection() {
 	std::lock_guard<std::mutex> lock(receiveMessageMutex_);
 	if(not client_) {

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -10,6 +10,8 @@
 
 namespace bringauto::modules {
 
+using ConvertibleBuffer = fleet_protocol::async_function_execution_definitions::ConvertibleBuffer;
+
 ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, const int moduleNumber) :
 		moduleBinaryPath_ { moduleBinaryPath } {
 	aeronClient.connect(moduleNumber);
@@ -72,10 +74,10 @@ int ModuleManagerLibraryHandlerAsync::sendStatusCondition(const Buffer &current_
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 
 	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::sendStatusConditionAsync,
@@ -94,13 +96,13 @@ int ModuleManagerLibraryHandlerAsync::generateCommand(Buffer &generated_command,
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_command_raw_buffer;
 
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (current_command.isAllocated()) {
-		current_command_raw_buffer = current_command.getStructBuffer();
+		current_command_raw_buffer = ConvertibleBuffer{current_command.getStructBuffer()};
 	}
 
 	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::generateCommandAsync,
@@ -129,10 +131,10 @@ int ModuleManagerLibraryHandlerAsync::aggregateStatus(Buffer &aggregated_status,
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 
 	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::aggregateStatusAsync,
@@ -162,10 +164,10 @@ int ModuleManagerLibraryHandlerAsync::aggregateError(Buffer &error_message,
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer status_raw_buffer;
 
 	if (current_error_message.isAllocated()) {
-		current_error_raw_buffer = current_error_message.getStructBuffer();
+		current_error_raw_buffer = ConvertibleBuffer{current_error_message.getStructBuffer()};
 	}
 	if (status.isAllocated()) {
-		status_raw_buffer = status.getStructBuffer();
+		status_raw_buffer = ConvertibleBuffer{status.getStructBuffer()};
 	}
 
 	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::aggregateErrorAsync,
@@ -201,7 +203,7 @@ int ModuleManagerLibraryHandlerAsync::statusDataValid(const Buffer &status, unsi
 	std::lock_guard lock { statusDataValidMutex_ };
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer status_raw_buffer;
 	if (status.isAllocated()) {
-		status_raw_buffer = status.getStructBuffer();
+		status_raw_buffer = ConvertibleBuffer{status.getStructBuffer()};
 	}
 
 	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::statusDataValidAsync,
@@ -213,7 +215,7 @@ int ModuleManagerLibraryHandlerAsync::commandDataValid(const Buffer &command, un
 	std::lock_guard lock { commandDataValidMutex_ };
 	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer command_raw_buffer;
 	if (command.isAllocated()) {
-		command_raw_buffer = command.getStructBuffer();
+		command_raw_buffer = ConvertibleBuffer{command.getStructBuffer()};
 	}
 
 	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::commandDataValidAsync,

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -44,6 +44,10 @@ public:
 	void setCommandMsgBadSessionId(bool commandMsgBadSessionId);
 	void setCommandMsgModuleNotExists(bool commandMsgModuleNotExists);
 
+	void setConnected(bool connected);
+
+	int receiveMessageCallCount() const;
+
 private:
 	enum NextMessageType {
 		CONNECT_RESPONSE,
@@ -69,6 +73,9 @@ private:
 	bool commandMsgNoType_ { false };
 	bool commandMsgBadSessionId_ { false };
 	bool commandMsgModuleNotExists_ { false };
+
+	bool connected_ { true };
+	int receiveMessageCallCount_ { 0 };
 };
 
 }

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -22,6 +22,8 @@ public:
 
 	void closeConnection() override;
 
+	bool isConnected() const override;
+
 	std::string getSessionId() const;
 
 	void setFailOnInitConnection(bool failOnInitConnection);

--- a/test/source/ExternalConnectionTests.cpp
+++ b/test/source/ExternalConnectionTests.cpp
@@ -138,6 +138,84 @@ TEST_F(ExternalConnectionTests, FailedConnectionSequenceOnCommandModuleNotExists
 
 
 /**
+ * @brief Trigger a server-side disconnect after a successful handshake.
+ * Verify that the receiving loop detects the disconnect and pushes an item
+ * onto the reconnect queue.
+ */
+TEST_F(ExternalConnectionTests, DisconnectDetectionPushesToReconnectQueue) {
+	ASSERT_EQ(externalConnection_->initializeConnection(connectedDevices_), 0);
+	ASSERT_EQ(externalConnection_->getState(), bringauto::external_client::connection::ConnectionState::CONNECTED);
+
+	communicationChannel_->setConnected(false);
+
+	// The receiving loop calls receiveMessage() -> nullptr, then isConnected() -> false,
+	// and pushes to reconnectQueue_ via pushAndNotify. Wait up to 5 seconds.
+	const bool queueStillEmpty = reconnectQueue_->waitForValueWithTimeout(std::chrono::seconds(5));
+	ASSERT_FALSE(queueStillEmpty);
+}
+
+
+/**
+ * @brief When receiveMessage() returns nullptr but isConnected() is still true (timeout path),
+ * the receiving loop must NOT push anything onto the reconnect queue.
+ */
+TEST_F(ExternalConnectionTests, ReceiveTimeoutWithConnectedDoesNotTriggerReconnect) {
+	ASSERT_EQ(externalConnection_->initializeConnection(connectedDevices_), 0);
+	ASSERT_EQ(externalConnection_->getState(), bringauto::external_client::connection::ConnectionState::CONNECTED);
+
+	// After the handshake, nextMessageType_ is CONNECT_RESPONSE.
+	// setConnectMsgNullptr(true) makes receiveMessage() return nullptr while isConnected() stays true.
+	communicationChannel_->setConnectMsgNullptr(true);
+
+	// Wait a short time and verify nothing was pushed to the reconnect queue.
+	const bool queueStillEmpty = reconnectQueue_->waitForValueWithTimeout(std::chrono::seconds(2));
+	ASSERT_TRUE(queueStillEmpty);
+}
+
+
+/**
+ * @brief Regression test for the stopReceiving reset race fixed in deinitializeConnection.
+ * Simulate: successful connect -> disconnect detection -> deinitializeConnection -> initializeConnection.
+ * Verify the new listening thread is actually running by triggering a second disconnect detection.
+ */
+TEST_F(ExternalConnectionTests, ReinitializationAfterDisconnectTriggeredExit) {
+	ASSERT_EQ(externalConnection_->initializeConnection(connectedDevices_), 0);
+	ASSERT_EQ(externalConnection_->getState(), bringauto::external_client::connection::ConnectionState::CONNECTED);
+
+	// First disconnect: loop sees nullptr + isConnected()==false and exits via return.
+	communicationChannel_->setConnected(false);
+	const bool firstQueueEmpty = reconnectQueue_->waitForValueWithTimeout(std::chrono::seconds(5));
+	ASSERT_FALSE(firstQueueEmpty);
+
+	// Drain the reconnect queue item from the first disconnect.
+	reconnectQueue_->pop();
+
+	// Deinitialize. The fix in deinitializeConnection ensures stopReceiving is cleared after join,
+	// eliminating the race where the new thread could see stopReceiving==true on startup.
+	externalConnection_->deinitializeConnection(false);
+
+	// Restore mock to a working state for the second handshake.
+	communicationChannel_->setConnected(true);
+
+	// Re-populate the error aggregator: initializeConnection's statusMessageHandle requires
+	// a last status for each device. The first run cleared it via clear_error_aggregator().
+	externalConnection_->fillErrorAggregator(bringauto::common_utils::ProtobufUtils::createDeviceStatus(
+		connectedDevices_[0], create_buffer("status")));
+
+	ASSERT_EQ(externalConnection_->initializeConnection(connectedDevices_), 0);
+	ASSERT_EQ(externalConnection_->getState(), bringauto::external_client::connection::ConnectionState::CONNECTED);
+
+	// Trigger a second disconnect. If the new listening thread is running, it will detect
+	// the disconnect and push onto reconnectQueue_. If stopReceiving were stuck true,
+	// the thread would have exited without ever polling receiveMessage() and nothing would
+	// be pushed.
+	communicationChannel_->setConnected(false);
+	const bool secondQueueEmpty = reconnectQueue_->waitForValueWithTimeout(std::chrono::seconds(5));
+	ASSERT_FALSE(secondQueueEmpty);
+}
+
+
+/**
  * @brief Test the changing of the session id.
  * The session id should change every time the connection is initialized, and its length should be 8.
  */

--- a/test/source/testing_utils/CommunicationMock.cpp
+++ b/test/source/testing_utils/CommunicationMock.cpp
@@ -35,6 +35,12 @@ bool CommunicationMock::sendMessage(ExternalProtocol::ExternalClient* message) {
 }
 
 std::shared_ptr<ExternalProtocol::ExternalServer> CommunicationMock::receiveMessage() {
+	++receiveMessageCallCount_;
+
+	if (!connected_) {
+		return nullptr;
+	}
+
 	auto ptr = std::make_shared<ExternalProtocol::ExternalServer>();
 
 	switch (nextMessageType_) {
@@ -112,7 +118,7 @@ void CommunicationMock::closeConnection() {
 }
 
 bool CommunicationMock::isConnected() const {
-	return true;
+	return connected_;
 }
 
 std::string CommunicationMock::getSessionId() const {
@@ -173,6 +179,14 @@ void CommunicationMock::setCommandMsgBadSessionId(bool commandMsgBadSessionId) {
 
 void CommunicationMock::setCommandMsgModuleNotExists(bool commandMsgModuleNotExists) {
 	commandMsgModuleNotExists_ = commandMsgModuleNotExists;
+}
+
+void CommunicationMock::setConnected(bool connected) {
+	connected_ = connected;
+}
+
+int CommunicationMock::receiveMessageCallCount() const {
+	return receiveMessageCallCount_;
 }
 
 }

--- a/test/source/testing_utils/CommunicationMock.cpp
+++ b/test/source/testing_utils/CommunicationMock.cpp
@@ -111,6 +111,10 @@ std::shared_ptr<ExternalProtocol::ExternalServer> CommunicationMock::receiveMess
 void CommunicationMock::closeConnection() {
 }
 
+bool CommunicationMock::isConnected() const {
+	return true;
+}
+
 std::string CommunicationMock::getSessionId() const {
 	return sessionId_;
 }


### PR DESCRIPTION
- Add `isConnected()` to `ICommunicationChannel` and implement in `MqttCommunication` and `DummyCommunication`
- Detect external server disconnect in `receivingHandlerLoop` and trigger reconnect when `receiveMessage` returns null but channel is disconnected
- Fix `ConvertibleBuffer` explicit constructor assignment errors in `ModuleManagerLibraryHandlerAsync` by using direct initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Communication channels expose a connection-status query for real-time connectivity checks.

* **Bug Fixes**
  * Receiving loop more reliably detects disconnects and enqueues reconnection requests sooner.

* **Refactor**
  * Module handlers use a unified buffer conversion for more consistent data passing.

* **Tests**
  * Mocks extended with connectivity controls and counters; new tests cover disconnect and reinitialization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->