### PR TITLE
BAF-1404: Active reconnect on external server disconnect - MQTT

### DIFF
--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -36,6 +36,8 @@ public:
 
 	void cancelReceive() override { /* receiveMessage() always returns nullptr — nothing to unblock */ }
 
+	bool consumeServerDisconnectNotification() override { return false; }
+
 private:
 	/// Flag to indicate if the fake connection is established
 	bool isConnected_ { false };

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -54,6 +54,16 @@ public:
 	 */
 	virtual void cancelReceive() = 0;
 
+	/**
+	 * @brief Check whether the external server sent a disconnect notification.
+	 *
+	 * Returns true and clears the internal flag if a disconnect notification has
+	 * been received since the last call. Returns false otherwise.
+	 * Used by ExternalConnection to trigger an immediate reconnect instead of
+	 * waiting for the status_response_timeout to expire.
+	 */
+	virtual bool consumeServerDisconnectNotification() = 0;
+
 protected:
 	/// Instance of the specific settings for the communication channel
 	structures::ExternalConnectionSettings settings_ {};

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -30,6 +30,8 @@ public:
 	// Paho MQTT does not expose a blocking-consumer interrupt; shutdown waits up to receive_message_timeout.
 	void cancelReceive() override {}
 
+	bool consumeServerDisconnectNotification() override;
+
 private:
 	void connect();
 
@@ -60,6 +62,8 @@ private:
 	 */
 	static std::string createSubscribeTopic(const std::string &company, const std::string &vehicleName);
 
+	static std::string createServerDisconnectTopic(const std::string &company, const std::string &vehicleName);
+
 	/// MQTT client handling the connection
 	std::unique_ptr<mqtt::async_client> client_ { nullptr };
 	/// Unique ID of the client, changes with every connection
@@ -68,6 +72,10 @@ private:
 	std::string publishTopic_ {};
 	/// Topic to subscribe to, sender is external server, receiver is external client
 	std::string subscribeTopic_ {};
+	/// Topic to subscribe to for server disconnect notifications
+	std::string serverDisconnectTopic_ {};
+	/// Set to true when a disconnect notification has been received from the external server
+	std::atomic<bool> serverDisconnectPending_ { false };
 	/// MQTT library connection options
 	mqtt::connect_options connopts_ {};
 	/// Address of the MQTT server

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -80,6 +80,8 @@ namespace bringauto::external_client::connection::communication {
 
 		void cancelReceive() override;
 
+		bool consumeServerDisconnectNotification() override { return false; }
+
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -346,6 +346,11 @@ void ExternalConnection::receivingHandlerLoop() {
 			continue;
 		}
 		const auto serverMessage = communicationChannel_->receiveMessage();
+		if(communicationChannel_->consumeServerDisconnectNotification()) {
+			log::logInfo("External server sent disconnect notification, triggering immediate reconnect");
+			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			return;
+		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
 			continue;
 		}

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -29,6 +29,7 @@ MqttCommunication::~MqttCommunication() {
 void MqttCommunication::setProperties(const std::string& company, const std::string& vehicleName) {
 	publishTopic_ = createPublishTopic(company, vehicleName);
 	subscribeTopic_ = createSubscribeTopic(company, vehicleName);
+	serverDisconnectTopic_ = createServerDisconnectTopic(company, vehicleName);
 	clientId_ = createClientId(company, vehicleName);
 
 	serverAddress_ = {
@@ -82,6 +83,8 @@ void MqttCommunication::connect() {
 
 	const auto substok = client_->subscribe(subscribeTopic_, qos);
 	substok->wait();
+	const auto disctok = client_->subscribe(serverDisconnectTopic_, qos);
+	disctok->wait();
 }
 
 bool MqttCommunication::sendMessage(ExternalProtocol::ExternalClient* message) {
@@ -111,6 +114,12 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 		return nullptr;
 	}
 
+	if(msg->get_topic() == serverDisconnectTopic_) {
+		settings::Logger::logInfo("Received server disconnect notification on topic '{}'", serverDisconnectTopic_);
+		serverDisconnectPending_.store(true);
+		return nullptr;
+	}
+
 	auto ptr = std::make_shared<ExternalProtocol::ExternalServer>();
 	if (!ptr->ParseFromArray(msg->get_payload_str().c_str(), static_cast<int>(msg->get_payload_str().size()))) {
 		settings::Logger::logError("Failed to parse protobuf message from external server");
@@ -119,13 +128,19 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 	return ptr;
 }
 
+bool MqttCommunication::consumeServerDisconnectNotification() {
+	return serverDisconnectPending_.exchange(false);
+}
+
 void MqttCommunication::closeConnection() {
 	std::lock_guard<std::mutex> lock(receiveMessageMutex_);
+	serverDisconnectPending_.store(false);
 	if(not client_) {
 		return;
 	}
 	if(client_->is_connected()) {
 		client_->unsubscribe(subscribeTopic_);
+		client_->unsubscribe(serverDisconnectTopic_);
 		client_->disconnect();
 	}
 	client_.reset();
@@ -141,6 +156,10 @@ std::string MqttCommunication::createPublishTopic(const std::string &company, co
 
 std::string MqttCommunication::createSubscribeTopic(const std::string &company, const std::string &vehicleName) {
 	return createClientId(company, vehicleName) + std::string("/external_server");
+}
+
+std::string MqttCommunication::createServerDisconnectTopic(const std::string &company, const std::string &vehicleName) {
+	return createClientId(company, vehicleName) + std::string("/external_server_disconnect");
 }
 
 

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -24,6 +24,8 @@ public:
 
 	void cancelReceive() override { /* no-op: mock receiveMessage() is controlled via queued messages */ }
 
+	bool consumeServerDisconnectNotification() override { return false; }
+
 	std::string getSessionId() const;
 
 	void setFailOnInitConnection(bool failOnInitConnection);


### PR DESCRIPTION
Subscribes to the external server's disconnect notification topic over MQTT and triggers immediate reconnection on receipt, reducing recovery time from ~30s to under 5s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for server disconnect notification handling. The system now detects when the server becomes unavailable and automatically initiates a reconnection attempt, improving reliability and responsiveness to connection state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->