### PR TITLE
BAF-1404: drop connection on server disconnect when no devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Key CMake options:
 - `BRINGAUTO_INSTALL` — enable install target
 - `BRINGAUTO_PACKAGE` — enable packaging (forces INSTALL=ON)
 - `BRINGAUTO_SYSTEM_DEP` — use system deps instead of fetching
+- `BRINGAUTO_SANITIZERS` — enable AddressSanitizer/UBSan/LeakSanitizer (default ON; set OFF for cross-compilation, e.g. aarch64)
 - `BRINGAUTO_MODULE_GATEWAY_MINIMUM_LOGGER_VERBOSITY` — compile-time log level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
 
 ## Tests

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -347,8 +347,8 @@ void ExternalConnection::receivingHandlerLoop() {
 		}
 		const auto serverMessage = communicationChannel_->receiveMessage();
 		if(communicationChannel_->consumeServerDisconnectNotification()) {
-			log::logInfo("External server sent disconnect notification, triggering immediate reconnect");
-			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
+			log::logInfo("External server sent disconnect notification, dropping connection until new device connects");
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), false));
 			return;
 		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {


### PR DESCRIPTION
## Summary
- On server disconnect notification, push `ReconnectQueueItem(reconnect=false)` instead of `reconnect=true`
- GW drops the connection and waits in `NOT_INITIALIZED` state
- Reconnect is triggered lazily by the next incoming device status via the existing `sendStatus()` path

## Test plan
- [ ] Verify GW does not attempt to reconnect after server disconnect with 0 devices
- [ ] Verify GW reconnects normally when a new device connects after the drop
- [ ] Verify immediate reconnect still works for other disconnect causes (not-acked timeout path is unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build documentation with CMake sanitizer configuration options.

* **Bug Fixes**
  * Modified server disconnect handling to properly manage reconnection behavior and prevent immediate reconnection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->