### PR TITLE
BAF-1465: use pushAndNotify for reconnectQueue_ to fix delayed shutdown

### DIFF
--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -188,26 +188,17 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 
 void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
                                               std::atomic<bool> &connectDone) {
-	std::optional<structures::InternalClientMessage> deferredDisconnect;
 	while (!connectDone.load() && !context_->ioContext.stopped() &&
 	       connection.getState() != connection::ConnectionState::CONNECTED) {
 		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
 			continue;
 		}
-		// Re-check after unblocking: connection may have finished while we were waiting.
-		// Without this, we could pop and feed fillErrorAggregator after clear_error_aggregator already ran.
-		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED) {
-			break;
-		}
-		// Do not drain disconnect messages — they must reach handleAggregatedMessages
-		// so the device is properly removed from connectedDevices_ via deleteConnectedDevice().
-		// Consuming a disconnect here would leave the device in connectedDevices_ after the
-		// connect sequence, causing the gateway and server to lose sync on device state.
-		// Pop it into deferredDisconnect so any messages after it can still be processed,
-		// then re-push it after the loop so handleAggregatedMessages sees it.
-		if (toExternalQueue_->front().disconnected()) {
-			deferredDisconnect = std::move(toExternalQueue_->front());
-			toExternalQueue_->pop();
+		// Re-check after unblocking, and do not consume disconnect messages —
+		// both must reach handleAggregatedMessages (the former to avoid feeding
+		// fillErrorAggregator after clear_error_aggregator ran; the latter so the
+		// device is properly removed via deleteConnectedDevice()).
+		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED ||
+		    toExternalQueue_->front().disconnected()) {
 			break;
 		}
 		const auto internalMessage = std::move(toExternalQueue_->front());
@@ -218,9 +209,6 @@ void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &con
 		} else {
 			sendStatus(internalMessage);
 		}
-	}
-	if (deferredDisconnect.has_value()) {
-		toExternalQueue_->pushAndNotify(std::move(*deferredDisconnect));
 	}
 }
 

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -304,7 +304,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(connection), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(connection), true));
 			settings::Logger::logDebug("Reconnect timer expired");
 		});
 	}

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -24,7 +24,7 @@ ExternalConnection::ExternalConnection(const std::shared_ptr<structures::GlobalC
 		commandQueue_ { commandQueue },
 		reconnectQueue_ { reconnectQueue } {
 	sentMessagesHandler_ = std::make_unique<messages::SentMessagesHandler>(context, [this]() {
-		reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+		reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 	});
 }
 
@@ -348,7 +348,7 @@ void ExternalConnection::receivingHandlerLoop() {
 		const auto serverMessage = communicationChannel_->receiveMessage();
 		if(communicationChannel_->consumeServerDisconnectNotification()) {
 			log::logInfo("External server sent disconnect notification, triggering immediate reconnect");
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 			return;
 		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
@@ -358,7 +358,7 @@ void ExternalConnection::receivingHandlerLoop() {
 			const auto &command = serverMessage->command();
 			log::logDebug("Handling COMMAND messageCounter={}", command.messagecounter());
 			if(handleCommand(command) != OK) {
-				reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+				reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 				return;
 			}
 		} else if(serverMessage->has_statusresponse()) {
@@ -370,7 +370,7 @@ void ExternalConnection::receivingHandlerLoop() {
 			}
 		} else {
 			log::logError("Received message with unexpected type(connect response), closing connection");
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 			return;
 		}
 


### PR DESCRIPTION
## Summary
- All `reconnectQueue_->push()` calls replaced with `pushAndNotify()` so the condition variable is notified whenever a reconnect item is queued.
- Fixes a force-kill at teardown of integration test ts_250: the 10 s `immediate_disconnect_timeout` wait in `handleAggregatedMessages()` never woke early because `push()` skipped CV notification, causing the process to ignore SIGTERM until the wait expired — past the 5 s kill window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved disconnect message handling during connection sequences.
  * Enhanced reconnection timer notifications for more timely queue processing.
  * Standardized reconnection queue notifications across multiple connection recovery paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->