### PR TITLE
BAF-1465: use pushAndNotify for reconnectQueue_ to fix delayed shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build
+
+Requires an external CMake library (`CMLIB_DIR`):
+
+```bash
+# Standard build
+mkdir -p _build && cd _build
+cmake ../ -DCMLIB_DIR=</absolute/path/to/cmakelib>
+make
+
+# Build with tests — must use clang++-17 (gcc causes AddressSanitizer crashes)
+mkdir -p _build_tests && cd _build_tests
+cmake ../ -DCMLIB_DIR=</absolute/path/to/cmakelib> -DBRINGAUTO_TESTS=ON -DCMAKE_CXX_COMPILER=clang++-17
+make
+```
+
+Key CMake options:
+- `BRINGAUTO_TESTS` — enable tests (requires clang++-17)
+- `BRINGAUTO_INSTALL` — enable install target
+- `BRINGAUTO_PACKAGE` — enable packaging (forces INSTALL=ON)
+- `BRINGAUTO_SYSTEM_DEP` — use system deps instead of fetching
+- `BRINGAUTO_MODULE_GATEWAY_MINIMUM_LOGGER_VERBOSITY` — compile-time log level (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+
+## Tests
+
+```bash
+# Run all tests
+cd _build_tests && ctest
+
+# Run a specific test binary directly (e.g. for verbose output)
+cd _build_tests && ./test/ModuleHandlerTests
+```
+
+Tests use port 8888 for the internal server — it must be free when running `InternalServerTests`.
+
+## Run
+
+```bash
+./module-gateway-app --config-path=../resources/config/default.json
+# Optional: --port=<unsigned short>  overrides the internal server port
+```
+
+## Architecture
+
+The gateway bridges internal device clients with external servers. Three main components cooperate via `AtomicQueue`-based message passing:
+
+```
+Internal Client ──► Internal Server ──► [fromInternalQueue] ──► Module Handler
+                                                                       │
+                                                              Module Libraries &
+                                                              Status Aggregators
+                                                                       │
+                ◄── Internal Client ◄── [toInternalQueue] ◄───────────┤
+                                                                       │
+                External Client ◄────── [toExternalQueue] ◄───────────┘
+                      │
+              Error Aggregator
+                      │
+              External Server (MQTT / QUIC / Dummy)
+```
+
+### Internal Server (`internal_server/`)
+Accepts TCP connections from internal clients (devices). Messages are length-prefixed (4-byte little-endian). Forwards device messages to Module Handler; returns responses to the originating client.
+
+### Module Handler (`modules/`)
+The processing core. Loads module shared libraries via `library_loader.hpp`, manages a `StatusAggregator` per device, and routes messages between Internal Server and External Client. Supports local execution (`ModuleManagerLibraryHandlerLocal`) and async shared-memory execution (`ModuleManagerLibraryHandlerAsync`).
+
+### External Client (`external_client/`)
+Manages connections to one or more external server endpoints. Handles reconnection with backoff via `ReconnectQueueItem`. Uses `ErrorAggregator` to buffer messages that failed to deliver. Protocol is abstracted behind `ICommunicationChannel`; concrete implementations: `MqttCommunication`, `QuicCommunication`, `DummyCommunication`.
+
+### Settings (`settings/`)
+JSON config is parsed by `SettingsParser` (and `QuicSettingsParser` for QUIC-specific fields) into `Settings`. Configuration examples are in `resources/config/`.
+
+### Key shared structures (`structures/`)
+- `GlobalContext` — holds `boost::asio::io_context` and `shared_ptr<Settings>`, passed everywhere
+- `AtomicQueue<T>` — thread-safe queue used for all inter-component communication
+- `DeviceIdentification` — unique key for a device (module + device type + device role + device name + priority)
+
+## Language & Conventions
+
+- C++23, compiled with `-Wall -Wextra -Wpedantic`
+- AddressSanitizer + UBSan + LeakSanitizer are enabled in Debug/Test builds
+- Headers live in `include/bringauto/`, implementations mirror that path under `source/bringauto/`
+- Protobuf for serialization; Boost ASIO for async I/O; nlohmann-json for config parsing

--- a/CMLibStorage.cmake
+++ b/CMLibStorage.cmake
@@ -1,3 +1,7 @@
+FIND_PACKAGE(CMLIB REQUIRED COMPONENTS CMCONF)
+
+CMCONF_INIT_SYSTEM(FLEET_PROTOCOL)
+
 SET(STORAGE_LIST DEP)
 
 SET(STORAGE_LIST_DEP          "https://github.com/bacpack-system/package-tracker.git")

--- a/CMLibStorage.cmake
+++ b/CMLibStorage.cmake
@@ -5,3 +5,4 @@ CMCONF_INIT_SYSTEM(FLEET_PROTOCOL)
 SET(STORAGE_LIST DEP)
 
 SET(STORAGE_LIST_DEP          "https://github.com/bacpack-system/package-tracker.git")
+SET(STORAGE_LIST_DEP_REVISION "v2.0.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ FIND_PACKAGE(ZLIB 1.2.11 REQUIRED)
 FIND_PACKAGE(fleet-protocol-cxx-helpers-static 1.2.0 REQUIRED)
 FIND_PACKAGE(aeron 1.48.6 REQUIRED)
 FIND_PACKAGE(async-function-execution-shared 1.0.0 REQUIRED)
+FIND_PACKAGE(msquic CONFIG REQUIRED)
 
 FILE(GLOB_RECURSE source_files "source/*")
 ADD_LIBRARY(module-gateway-lib STATIC "${source_files}")
@@ -80,6 +81,7 @@ TARGET_LINK_LIBRARIES(module-gateway-lib PUBLIC
                         ZLIB::ZLIB
                         fleet-protocol-cxx-helpers-static::fleet-protocol-cxx-helpers-static
                         async-function-execution-shared::async-function-execution-shared
+                        msquic
                         ${CMAKE_DL_LIBS}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ OPTION(BRINGAUTO_INSTALL           "Enable install" OFF)
 OPTION(BRINGAUTO_SYSTEM_DEP        "Enable system dependencies" OFF)
 OPTION(BRINGAUTO_SAMPLES           "Enable build of sample app, not used in project" OFF)
 OPTION(BRINGAUTO_GET_PACKAGES_ONLY "Only download packages for this project" OFF)
+OPTION(BRINGAUTO_SANITIZERS        "Enable address, undefined and leak sanitizers" ON)
 
 FIND_PACKAGE(CMLIB COMPONENTS CMCONF REQUIRED)
 CMCONF_INIT_SYSTEM(FLEET_PROTOCOL)
@@ -91,7 +92,7 @@ CMDEF_ADD_EXECUTABLE(
         VERSION ${BRINGAUTO_MODULE_GATEWAY_VERSION}
 )
 
-IF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR BRINGAUTO_TESTS)
+IF((CMAKE_BUILD_TYPE STREQUAL "Debug" OR BRINGAUTO_TESTS) AND BRINGAUTO_SANITIZERS)
     TARGET_COMPILE_OPTIONS(module-gateway-app PRIVATE -Wall -Wextra -Wpedantic
             -fsanitize=address,undefined,leak -fno-sanitize-recover )
     TARGET_LINK_OPTIONS(module-gateway-app PUBLIC -fsanitize=undefined,leak,address)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -12,6 +12,7 @@ BA_PACKAGE_LIBRARY(zlib                     v1.2.11 OUTPUT_PATH_VAR ZLIB_DIR)
 BA_PACKAGE_LIBRARY(fleet-protocol-cpp       v1.2.0)
 BA_PACKAGE_LIBRARY(aeron                    v1.48.6)
 BA_PACKAGE_LIBRARY(async-function-execution v1.0.0)
+BA_PACKAGE_LIBRARY(msquic                   v2.5.6)
 
 IF (BRINGAUTO_TESTS)
     BA_PACKAGE_LIBRARY(gtest v1.12.1)

--- a/include/bringauto/common_utils/EnumUtils.hpp
+++ b/include/bringauto/common_utils/EnumUtils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bringauto/external_client/connection/ConnectionState.hpp>
 #include <bringauto/structures/ExternalConnectionSettings.hpp>
 #include <bringauto/logging/LoggerVerbosity.hpp>
 #include <bringauto/settings/Constants.hpp>
@@ -32,6 +33,8 @@ public:
 		switch(toString) {
 			case structures::ProtocolType::MQTT:
 				return settings::Constants::MQTT;
+			case structures::ProtocolType::QUIC:
+				return settings::Constants::QUIC;
 			case structures::ProtocolType::DUMMY:
 				return settings::Constants::DUMMY;
 			case structures::ProtocolType::INVALID:
@@ -71,6 +74,31 @@ public:
 		}
 	};
 
-};
+	/**
+	 * @brief Converts connection state to string
+	 *
+	 * @param state external_client::connection::ConnectionState
+	 * @return std::string_view
+	 */
+	static constexpr std::string_view connectionStateToString(
+		external_client::connection::ConnectionState state
+	) {
+		using enum external_client::connection::ConnectionState;
 
+		switch (state) {
+			case NOT_INITIALIZED:
+				return settings::Constants::LOG_CONNECTION_STATE_NOT_INITIALIZED;
+			case NOT_CONNECTED:
+				return settings::Constants::LOG_CONNECTION_STATE_NOT_CONNECTED;
+			case CONNECTING:
+				return settings::Constants::LOG_CONNECTION_STATE_CONNECTING;
+			case CONNECTED:
+				return settings::Constants::LOG_CONNECTION_STATE_CONNECTED;
+			case CLOSING:
+				return settings::Constants::LOG_CONNECTION_STATE_CLOSING;
+			default:
+				return settings::Constants::LOG_UNKNOWN;
+		}
+	}
+	};
 }

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -9,6 +9,7 @@
 
 #include <InternalProtocol.pb.h>
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <unordered_map>

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -50,6 +50,17 @@ private:
 	void startExternalConnectSequence(connection::ExternalConnection &connection);
 
 	/**
+	 * @brief Drain toExternalQueue while a background connect attempt is in progress.
+	 * Feeds arriving statuses through fillErrorAggregator so the aggregate error count
+	 * stays in sync with the module's predictive check in sendStatusCondition.
+	 *
+	 * @param connection connection being initialised
+	 * @param connectDone atomic flag set to true by the background thread on completion
+	 */
+	void drainQueueDuringConnect(connection::ExternalConnection &connection,
+	                             std::atomic<bool> &connectDone);
+
+	/**
 	 * @brief Handle aggregated status messages from a module handler
 	 */
 	void handleAggregatedMessages();

--- a/include/bringauto/external_client/connection/ConnectionState.hpp
+++ b/include/bringauto/external_client/connection/ConnectionState.hpp
@@ -18,6 +18,10 @@ enum class ConnectionState {
 	/**
 	 * CONNECTED - Client is connected to the External server
 	 */
-	CONNECTED
+	CONNECTED,
+	/**
+	 * CLOSING - Client closing connection to the External server
+	 */
+	CLOSING
 };
 }

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -177,10 +177,6 @@ private:
 
 	std::shared_ptr <structures::AtomicQueue<structures::ReconnectQueueItem>>
 	reconnectQueue_ {};
-	/// Name of the vehicle
-	std::string vehicleName_ {};
-	/// Name of the company
-	std::string company_ {};
 };
 
 }

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -11,6 +11,7 @@
 #include <bringauto/structures/DeviceIdentification.hpp>
 #include <bringauto/structures/ReconnectQueueItem.hpp>
 
+#include <mutex>
 #include <string>
 #include <vector>
 #include <thread>
@@ -152,6 +153,13 @@ private:
 	 * Loop is receiving messages from external server and processes them.
 	 */
 	void receivingHandlerLoop();
+
+	/**
+	 * @brief Implementation of fillErrorAggregatorWithNotAckedStatuses without locking.
+	 * Must be called with errorAggregatorsMutex_ already held.
+	 */
+	void fillErrorAggregatorWithNotAckedStatusesImpl();
+
 	/// Indication if receiving loop should be stopped
 	std::atomic<bool> stopReceiving { false };
 	/// Length of the key used for identification
@@ -177,6 +185,8 @@ private:
 	const structures::ExternalConnectionSettings &settings_ {};
 	/// Class handling sent messages - timers, not acknowledged statuses etc.
 	std::unique_ptr <messages::SentMessagesHandler> sentMessagesHandler_ {};
+	/// Mutex guarding errorAggregators_ against concurrent access during the connect sequence
+	std::mutex errorAggregatorsMutex_ {};
 	/// @brief Map of error aggregators, key is module number
 	std::unordered_map<unsigned int, ErrorAggregator> errorAggregators_ {};
 	/// Queue of commands received from external server, commands are processed by aggregator

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -100,6 +100,13 @@ public:
 	void setNotInitialized();
 
 	/**
+	 * @brief Abort an in-progress connection attempt by closing the channel.
+	 * Fires SHUTDOWN_COMPLETE which wakes up any blocked receiveMessage() call.
+	 * Does NOT call fillErrorAggregatorWithNotAckedStatuses — safe to call during shutdown.
+	 */
+	void cancelPendingConnect();
+
+	/**
 	 * @brief Check if module type is supported
 	 *
 	 * @param moduleNum module type number

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -34,6 +34,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override {}  // DummyCommunication always returns nullptr from receiveMessage
+
 private:
 	/// Flag to indicate if the fake connection is established
 	bool isConnected_ { false };

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -34,7 +34,7 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override {}  // DummyCommunication always returns nullptr from receiveMessage
+	void cancelReceive() override { /* receiveMessage() always returns nullptr — nothing to unblock */ }
 
 private:
 	/// Flag to indicate if the fake connection is established

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -36,6 +36,8 @@ public:
 
 	void cancelReceive() override { /* receiveMessage() always returns nullptr — nothing to unblock */ }
 
+	bool consumeServerDisconnectNotification() override { return false; }
+
 private:
 	/// Flag to indicate if the fake connection is established
 	bool isConnected_ { false };

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -47,6 +47,13 @@ public:
 	 */
 	virtual void closeConnection() = 0;
 
+	/**
+	 * @brief Unblock any pending receiveMessage() call immediately.
+	 * Used during shutdown to abort an in-progress connect attempt without
+	 * the full receive_message_timeout delay.
+	 */
+	virtual void cancelReceive() = 0;
+
 protected:
 	/// Instance of the specific settings for the communication channel
 	structures::ExternalConnectionSettings settings_ {};

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -54,6 +54,16 @@ public:
 	 */
 	virtual void cancelReceive() = 0;
 
+	/**
+	 * @brief Check whether the external server sent a disconnect notification.
+	 *
+	 * Returns true and clears the internal flag if a disconnect notification has
+	 * been received since the last call. Returns false otherwise.
+	 * Used by ExternalConnection to trigger an immediate reconnect instead of
+	 * waiting for the status_response_timeout to expire.
+	 */
+	virtual bool consumeServerDisconnectNotification() = 0;
+
 protected:
 	/// Instance of the specific settings for the communication channel
 	structures::ExternalConnectionSettings settings_ {};

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,6 +27,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override {}  // MQTT receive cancellation handled by its own timeout
+
 private:
 	void connect();
 

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -30,6 +30,8 @@ public:
 	// Paho MQTT does not expose a blocking-consumer interrupt; shutdown waits up to receive_message_timeout.
 	void cancelReceive() override {}
 
+	bool consumeServerDisconnectNotification() override;
+
 private:
 	void connect();
 
@@ -60,6 +62,8 @@ private:
 	 */
 	static std::string createSubscribeTopic(const std::string &company, const std::string &vehicleName);
 
+	static std::string createServerDisconnectTopic(const std::string &company, const std::string &vehicleName);
+
 	/// MQTT client handling the connection
 	std::unique_ptr<mqtt::async_client> client_ { nullptr };
 	/// Unique ID of the client, changes with every connection
@@ -68,6 +72,10 @@ private:
 	std::string publishTopic_ {};
 	/// Topic to subscribe to, sender is external server, receiver is external client
 	std::string subscribeTopic_ {};
+	/// Topic to subscribe to for server disconnect notifications
+	std::string serverDisconnectTopic_ {};
+	/// Set to true when a disconnect notification has been received from the external server
+	std::atomic<bool> serverDisconnectPending_ { false };
 	/// MQTT library connection options
 	mqtt::connect_options connopts_ {};
 	/// Address of the MQTT server

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,7 +27,8 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override { /* MQTT receive cancellation handled by its own timeout */ }
+	// Paho MQTT does not expose a blocking-consumer interrupt; shutdown waits up to receive_message_timeout.
+	void cancelReceive() override {}
 
 private:
 	void connect();

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -27,7 +27,7 @@ public:
 
 	void closeConnection() override;
 
-	void cancelReceive() override {}  // MQTT receive cancellation handled by its own timeout
+	void cancelReceive() override { /* MQTT receive cancellation handled by its own timeout */ }
 
 private:
 	void connect();

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -1,0 +1,339 @@
+#pragma once
+
+#include <bringauto/external_client/connection/communication/ICommunicationChannel.hpp>
+#include <bringauto/external_client/connection/ConnectionState.hpp>
+
+#include <msquic.h>
+#include <nlohmann/json.hpp>
+
+#include <condition_variable>
+#include <filesystem>
+#include <queue>
+#include <thread>
+
+
+namespace bringauto::external_client::connection::communication {
+	class QuicCommunication : public ICommunicationChannel {
+	public:
+		explicit QuicCommunication(const structures::ExternalConnectionSettings &settings, const std::string &company,
+		                           const std::string &vehicleName);
+
+		~QuicCommunication() override;
+
+		/**
+		 * @brief Initializes a QUIC connection to the server.
+		 *
+		 * Attempts to establish a new QUIC connection.
+		 * It first atomically verifies that the current connection state is
+		 * NOT_CONNECTED and transitions it to CONNECTING in order to prevent
+		 * concurrent connection attempts.
+		 *
+		 * After the state transition, it opens a QUIC connection handle and
+		 * starts the connection using the configured server address, port,
+		 * and QUIC configuration.
+		 *
+		 * Any failures during the connection open or start process are logged.
+		 */
+		void initializeConnection() override;
+
+		/**
+		 * @brief Enqueues an outgoing message to be sent over the QUIC connection.
+		 *
+		 * Creates a shared copy of the provided ExternalClient message
+		 * and pushes it into the outbound message queue in a thread-safe manner.
+		 * After enqueuing, it notifies the sender thread via a condition variable
+		 * that a new message is available for sending.
+		 *
+		 * @param message Pointer to the message that should be sent.
+		 * @return true Always returns true to indicate the message was successfully enqueued.
+		 */
+		bool sendMessage(ExternalProtocol::ExternalClient *message) override;
+
+		/**
+		 * @brief Receives an incoming message from the QUIC connection.
+		 *
+		 * Waits for an incoming message to appear in the inbound
+		 * queue or for the connection state to change from CONNECTED.
+		 * The wait is bounded by a configurable timeout.
+		 *
+		 * If the wait times out, the connection is no longer in the CONNECTED
+		 * state, or no message is available, the function returns nullptr.
+		 * Otherwise, it retrieves and removes the next message from the inbound
+		 * queue and returns it.
+		 *
+		 * @return A shared pointer to the received ExternalServer message,
+		 *         or nullptr if no message is available or the connection is not active.
+		 */
+		std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
+
+		/**
+		 * @brief Initiates a graceful shutdown of the QUIC connection.
+		 *
+		 * Requests an orderly shutdown of the active QUIC connection.
+		 * If no connection is currently established, the function returns immediately.
+		 *
+		 * The shutdown is performed asynchronously. Completion is signaled via the
+		 * QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event, which is handled in
+		 * the connectionCallback.
+		 */
+		void closeConnection() override;
+
+	private:
+		/// Pointer to the MsQuic API function table
+		const QUIC_API_TABLE *quic_{nullptr};
+		/// QUIC registration handle associated with the application
+		HQUIC registration_{nullptr};
+		/// QUIC configuration handle (ALPN, credentials, transport settings)
+		HQUIC config_{nullptr};
+		/// Active QUIC connection handle
+		HQUIC connection_{nullptr};
+		/// Application-Layer Protocol Negotiation (ALPN) string
+		std::string alpn_;
+		/// QUIC buffer wrapping the ALPN string
+		QUIC_BUFFER alpnBuffer_{};
+
+		/// Path to the client certificate file
+		std::filesystem::path certFile_;
+		/// Path to the client private key file
+		std::filesystem::path keyFile_;
+		/// Path to the CA certificate file
+		std::filesystem::path caFile_;
+
+		/// Atomic state of the connection used for synchronization across threads
+		std::atomic<ConnectionState> connectionState_{ConnectionState::NOT_CONNECTED};
+
+		/// @name Inbound (peer → this)
+		/// @{
+		/// Queue of incoming messages received from the peer
+		std::queue<std::shared_ptr<ExternalProtocol::ExternalServer> > inboundQueue_;
+		/// Mutex protecting access to the inbound message queue
+		std::mutex inboundMutex_;
+		/// Condition variable for signaling inbound message availability
+		std::condition_variable inboundCv_;
+		/// @}
+
+		/// @name Outbound (this → peer)
+		/// @{
+		/// Queue of outgoing messages to be sent to the peer
+		std::queue<std::unique_ptr<ExternalProtocol::ExternalClient> > outboundQueue_;
+		/// Mutex protecting access to the outbound message queue
+		std::mutex outboundMutex_;
+		/// Condition variable for signaling outbound message availability
+		std::condition_variable outboundCv_;
+		/// Dedicated sender thread responsible for transmitting outbound messages
+		std::jthread senderThread_;
+		/// @}
+
+		/**
+		 * @brief Owns memory for a single MsQuic StreamSend operation.
+		 *
+		 * SendBuffer wraps a QUIC_BUFFER together with its backing storage.
+		 * The memory must remain valid until MsQuic signals
+		 * QUIC_STREAM_EVENT_SEND_COMPLETE, at which point it can be safely freed.
+		 *
+		 * Instances of this struct are typically allocated on the heap and passed
+		 * to MsQuic via the StreamSend ClientContext pointer.
+		 */
+		struct SendBuffer {
+			QUIC_BUFFER buffer{};
+			std::string storage;
+
+			/**
+			 * @brief Constructs a SendBuffer with zero-initialized storage.
+			 *
+			 * Allocates storage of the given size, fills it with zero bytes,
+			 * and initializes the QUIC_BUFFER to point to this storage.
+			 *
+			 * @param size Number of bytes to allocate for the send buffer.
+			 */
+			explicit SendBuffer(size_t size)
+				: storage(size, '\0') {
+				buffer.Length = static_cast<uint32_t>(storage.size());
+				buffer.Buffer = reinterpret_cast<uint8_t *>(storage.data());
+			}
+		};
+
+		/**
+		 * @brief Loads and initializes the MsQuic API.
+		 *
+		 * Initializes the MsQuic library and retrieves the
+		 * QUIC API function table. The resulting table is stored for later
+		 * use when creating registrations, configurations, and connections.
+		 *
+		 * If the initialization fails, an error is logged.
+		 */
+		void loadMsQuic();
+
+		/**
+		 * @brief Initializes a QUIC registration.
+		 *
+		 * Creates a QUIC registration with the specified application name and
+		 * a low-latency execution profile. The registration is required for
+		 * creating QUIC configurations and connections.
+		 *
+		 * If registration creation fails, an error is logged.
+		 */
+		void initRegistration();
+
+		/**
+		 * @brief Initializes the QUIC configuration and loads client credentials.
+		 *
+		 * Opens a QUIC configuration using the configured ALPN and default QUIC
+		 * transport settings. Client TLS credentials are then set up using a
+		 * certificate file, private key file, and CA certificate file.
+		 *
+		 * If configuration creation or credential loading fails, an error is logged.
+		 */
+		void initConfiguration();
+
+		/**
+		 * @brief Opens a QUIC configuration.
+		 *
+		 * Creates a QUIC configuration associated with the current registration,
+		 * configured ALPN, and optional transport settings.
+		 *
+		 * If settings are not provided, default QUIC settings are used.
+		 * On failure, an error is logged.
+		 */
+		void configurationOpen();
+
+		/**
+		 * @brief Loads TLS credentials into the QUIC configuration.
+		 *
+		 * Loads client-side TLS credentials into the active QUIC configuration.
+		 * The credentials define the certificate, private key, and CA certificate
+		 * used for secure communication.
+		 *
+		 * If credential loading fails, an error is logged.
+		 *
+		 * @param credential Pointer to the QUIC credential configuration.
+		 */
+		void configurationLoadCredential(const QUIC_CREDENTIAL_CONFIG *credential) const;
+
+		/**
+		 * @brief Handles a successfully decoded incoming message.
+		 *
+		 * Pushes the decoded ExternalServer message into the inbound queue
+		 * in a thread-safe manner and notifies the receiver thread that a
+		 * new message is available.
+		 *
+		 * @param msg Decoded message received from the peer.
+		 */
+		void onMessageDecoded(std::shared_ptr<ExternalProtocol::ExternalServer> msg);
+
+		/**
+		 * @brief Sends a message to the peer using a QUIC stream.
+		 *
+		 * Opens a new QUIC stream on the active connection and serializes the
+		 * provided ExternalClient message into a byte buffer.
+		 * The message is sent using a single StreamSend call with START and FIN
+		 * flags, effectively opening, sending, and closing the stream.
+		 *
+		 * The allocated send buffer is released asynchronously in the
+		 * QUIC_STREAM_EVENT_SEND_COMPLETE callback.
+		 *
+		 * @param message Message to be sent to the peer.
+		 */
+		void sendViaQuicStream(const ExternalProtocol::ExternalClient& message);
+
+		/**
+		 * @brief Closes the active QUIC configuration.
+		 */
+		void closeConfiguration();
+
+		/**
+		 * @brief Closes the QUIC registration.
+		 */
+		void closeRegistration();
+
+		/**
+		 * @brief Closes the MsQuic API and releases associated resources.
+		 */
+		void closeMsQuic();
+
+		/**
+		 * @brief Stops the QUIC communication and releases all resources.
+		 *
+		 * Initiates connection shutdown and closes the QUIC configuration,
+		 * registration, and MsQuic API in the correct order.
+		 * All waiting sender and receiver threads are unblocked by notifying
+		 * the associated condition variables.
+		 */
+		void stop();
+
+		/**
+		 * @brief Handles QUIC connection-level events.
+		 *
+		 * Processes connection lifecycle events reported by MsQuic, including
+		 * successful connection establishment, peer-initiated shutdown, and
+		 * shutdown completion.
+		 *
+		 * All QUIC_CONNECTION_EVENT cases are documented at
+		 * https://microsoft.github.io/msquic/msquicdocs/docs/api/QUIC_CONNECTION_EVENT.html
+		 *
+		 * @param connection QUIC connection handle.
+		 * @param context User-defined context pointer (QuicCommunication instance).
+		 * @param event Connection event information provided by MsQuic.
+		 * @return QUIC_STATUS_SUCCESS to indicate successful event handling.
+		 */
+		static QUIC_STATUS QUIC_API connectionCallback(HQUIC connection, void *context, QUIC_CONNECTION_EVENT *event); // NOSONAR - void* required by QUIC_CONNECTION_CALLBACK C API
+
+		/**
+		 * @brief Handles QUIC stream-level events.
+		 *
+		 * Processes stream events reported by MsQuic, including data reception,
+		 * send completion, stream startup, and shutdown notifications.
+		 *
+		 * All QUIC_STREAM_EVENT cases are documented at
+		 * https://microsoft.github.io/msquic/msquicdocs/docs/api/QUIC_STREAM_EVENT.html
+		 *
+		 * @param stream QUIC stream handle associated with the event.
+		 * @param context User-defined context pointer (QuicCommunication instance).
+		 * @param event Stream event information provided by MsQuic.
+		 * @return QUIC_STATUS_SUCCESS to indicate successful event handling.
+		 */
+		static QUIC_STATUS QUIC_API streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event); // NOSONAR - void* required by QUIC_STREAM_CALLBACK C API
+
+		/**
+		 * @brief Sender thread main loop for outbound messages.
+		 *
+		 * Waits for outbound messages while the connection is in the CONNECTED state.
+		 * Messages are dequeued and sent over individual QUIC streams.
+		 *
+		 * If sending fails, the message is re-enqueued for a later retry.
+		 * The loop terminates when the connection leaves the CONNECTED state.
+		 */
+		void senderLoop();
+
+		/**
+		 * @brief Retrieves the QUIC stream identifier for the given stream handle.
+		 *
+		 * Queries MsQuic for the stream ID associated with the provided HQUIC stream.
+		 * If the parameter query fails, an empty optional is returned.
+		 *
+		 * @param stream Valid QUIC stream handle.
+		 * @return Stream identifier on success, or std::nullopt if the query fails.
+		 */
+		std::optional<uint64_t> getStreamId(HQUIC stream);
+
+		/**
+		 * @brief Retrieves a protocol setting value as a plain string.
+		 *
+		 * Extracts a value from ExternalConnectionSettings::protocolSettings and
+		 * transparently handles values stored as JSON-encoded strings.
+		 *
+		 * Allows uniform access to protocol settings regardless of whether
+		 * they were stored as plain strings or JSON-serialized values.
+		 *
+		 * @param settings External connection settings containing protocolSettings.
+		 * @param key Key identifying the protocol setting.
+		 * @return Plain string value suitable for direct use (e.g. file paths).
+		 *
+		 * @throws std::out_of_range if the key is not present in protocolSettings.
+		 */
+		static std::string getProtocolSettingsString(
+			const structures::ExternalConnectionSettings &settings,
+			std::string_view key
+		);
+	};
+}

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -79,6 +79,14 @@ namespace bringauto::external_client::connection::communication {
 		void closeConnection() override;
 
 	private:
+		/// Directionality of QUIC streams created or accepted by this connection
+		enum class StreamMode {
+			/// Stream can only send data in one direction
+			Unidirectional,
+			/// Stream supports bidirectional send and receive
+			Bidirectional
+		};
+
 		/// Pointer to the MsQuic API function table
 		const QUIC_API_TABLE *quic_{nullptr};
 		/// QUIC registration handle associated with the application
@@ -98,6 +106,8 @@ namespace bringauto::external_client::connection::communication {
 		std::filesystem::path keyFile_;
 		/// Path to the CA certificate file
 		std::filesystem::path caFile_;
+
+		StreamMode streamMode_{StreamMode::Bidirectional};
 
 		/// Atomic state of the connection used for synchronization across threads
 		std::atomic<ConnectionState> connectionState_{ConnectionState::NOT_CONNECTED};
@@ -319,21 +329,40 @@ namespace bringauto::external_client::connection::communication {
 		/**
 		 * @brief Retrieves a protocol setting value as a plain string.
 		 *
-		 * Extracts a value from ExternalConnectionSettings::protocolSettings and
-		 * transparently handles values stored as JSON-encoded strings.
+		 * Looks up a value in ExternalConnectionSettings::protocolSettings and returns
+		 * it as a plain string. If the stored value is a JSON-encoded string, it is
+		 * transparently parsed and unwrapped.
 		 *
-		 * Allows uniform access to protocol settings regardless of whether
-		 * they were stored as plain strings or JSON-serialized values.
+		 * If the key does not exist or the value cannot be parsed as valid JSON,
+		 * the provided default value is returned and a warning is logged.
+		 *
+		 * This allows uniform access to protocol settings regardless of whether
+		 * they are stored as plain strings or JSON-serialized strings.
 		 *
 		 * @param settings External connection settings containing protocolSettings.
 		 * @param key Key identifying the protocol setting.
+		 * @param defaultValue Value returned if the key is missing or invalid.
 		 * @return Plain string value suitable for direct use (e.g. file paths).
-		 *
-		 * @throws std::out_of_range if the key is not present in protocolSettings.
 		 */
 		static std::string getProtocolSettingsString(
 			const structures::ExternalConnectionSettings &settings,
-			std::string_view key
+			std::string_view key,
+			std::string defaultValue = {}
 		);
+
+		/**
+		 * @brief Parses QUIC stream mode from protocol settings.
+		 *
+		 * Reads the stream mode from the external connection settings and determines
+		 * whether QUIC streams should be unidirectional or bidirectional.
+		 *
+		 * Supported values:
+		 *  - "unidirectional", "unidir" → Unidirectional streams
+		 *  - any other value or missing setting → Bidirectional streams (default)
+		 *
+		 * @param settings External connection settings containing QUIC protocol options
+		 * @return StreamMode Parsed stream mode (defaults to Bidirectional)
+		 */
+		static StreamMode parseStreamMode(const structures::ExternalConnectionSettings &settings);
 	};
 }

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -81,7 +81,12 @@ namespace bringauto::external_client::connection::communication {
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {
-			/// Stream can only send data in one direction
+			/// Stream can only send data in one direction.
+			/// In this mode each sendMessage() call opens a new outbound stream that is
+			/// immediately closed after the send (START | FIN flags). The peer opens
+			/// separate streams in the opposite direction for responses. Many short-lived
+			/// streams are created over the connection lifetime, but QUIC stream creation
+			/// is lightweight and has no significant impact on performance.
 			Unidirectional,
 			/// Stream supports bidirectional send and receive
 			Bidirectional

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -78,6 +78,8 @@ namespace bringauto::external_client::connection::communication {
 		 */
 		void closeConnection() override;
 
+		void cancelReceive() override;
+
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {
@@ -116,6 +118,9 @@ namespace bringauto::external_client::connection::communication {
 
 		/// Atomic state of the connection used for synchronization across threads
 		std::atomic<ConnectionState> connectionState_{ConnectionState::NOT_CONNECTED};
+
+		/// Set by cancelReceive() to unblock a pending receiveMessage() call immediately
+		std::atomic<bool> cancelReceive_{false};
 
 		/// @name Inbound (peer → this)
 		/// @{

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -80,6 +80,8 @@ namespace bringauto::external_client::connection::communication {
 
 		void cancelReceive() override;
 
+		bool consumeServerDisconnectNotification() override { return false; }
+
 	private:
 		/// Directionality of QUIC streams created or accepted by this connection
 		enum class StreamMode {

--- a/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
+++ b/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <filesystem>
-#include <functional>
 
 
 
@@ -51,7 +50,8 @@ public:
 	 * @param device_type device type
 	 * @return OK if the new status should be aggregated, NOT_OK otherwise
 	 */
-	virtual int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const = 0;
+	virtual int sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                                unsigned int device_type) const = 0;
 
 	/**
 	 * @brief After executing the respective module function, an error might be thrown when allocating the buffer.

--- a/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
+++ b/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
@@ -2,6 +2,9 @@
 
 #include <bringauto/modules/Buffer.hpp>
 
+#include <fleet_protocol/common_headers/memory_management.h>
+
+#include <functional>
 #include <filesystem>
 #include <functional>
 
@@ -30,7 +33,7 @@ public:
 	 *
 	 * @return module number
 	 */
-	virtual int getModuleNumber() = 0;
+	virtual int getModuleNumber() const = 0;
 
 	/**
 	 * @brief Check if device type is supported by the module
@@ -48,7 +51,7 @@ public:
 	 * @param device_type device type
 	 * @return OK if the new status should be aggregated, NOT_OK otherwise
 	 */
-	virtual int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) = 0;
+	virtual int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const = 0;
 
 	/**
 	 * @brief After executing the respective module function, an error might be thrown when allocating the buffer.
@@ -89,7 +92,7 @@ public:
 	 * @param device_type device type
 	 * @return OK if valid, NOT_OK otherwise
 	 */
-	virtual int statusDataValid(const Buffer &status, unsigned int device_type) = 0;
+	virtual int statusDataValid(const Buffer &status, unsigned int device_type) const = 0;
 
 	/**
 	 * @brief Check if the command data is valid
@@ -98,7 +101,7 @@ public:
 	 * @param device_type device type
 	 * @return OK if valid, NOT_OK otherwise
 	 */
-	virtual int commandDataValid(const Buffer &command, unsigned int device_type) = 0;
+	virtual int commandDataValid(const Buffer &command, unsigned int device_type) const = 0;
 
 	/**
 	 * @brief Constructs a buffer with the given size

--- a/include/bringauto/modules/ModuleBinaryException.hpp
+++ b/include/bringauto/modules/ModuleBinaryException.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdexcept>
+
+
+
+namespace bringauto::modules {
+
+/**
+ * @brief Exception thrown when the module binary fails to start or become ready
+ */
+class ModuleBinaryException : public std::runtime_error {
+public:
+	using std::runtime_error::runtime_error;
+};
+
+}

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <bringauto/modules/IModuleManagerLibraryHandler.hpp>
-#include <bringauto/settings/Constants.hpp>
 
-#include <bringauto/async_function_execution/AsyncFunctionExecutor.hpp>
-#include <bringauto/fleet_protocol/async_function_execution_definitions/AsyncModuleFunctionDefinitions.hpp>
 #include <boost/process.hpp>
 
+#include <filesystem>
 #include <mutex>
+#include <span>
 
 
 
@@ -18,7 +17,7 @@ namespace bringauto::modules {
  */
 class ModuleManagerLibraryHandlerAsync : public IModuleManagerLibraryHandler {
 public:
-	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, const int moduleNumber);
+	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath);
 
 	~ModuleManagerLibraryHandlerAsync() override;
 
@@ -28,31 +27,53 @@ public:
 	ModuleManagerLibraryHandlerAsync &operator=(ModuleManagerLibraryHandlerAsync &&) = delete;
 
 	/**
-	 * @brief Spawns the module binary process and waits for it to be ready via Aeron IPC.
+	 * @brief Load library created by a module maintainer
+	 *
+	 * @param path path to the library
 	 */
 	void loadLibrary(const std::filesystem::path &path) override;
 
-	int getModuleNumber() override;
+	int getModuleNumber() const override;
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) override;
+	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
 
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 *
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
 	int generateCommand(Buffer &generated_command, const Buffer &new_status,
 						const Buffer &current_status, const Buffer &current_command,
 						unsigned int device_type) override;
 
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 *
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
 	int aggregateStatus(Buffer &aggregated_status, const Buffer &current_status,
 						const Buffer &new_status, unsigned int device_type) override;
 
-	int aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
-					   unsigned int device_type) override;
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 *
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
+	int	aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
+						  unsigned int device_type) override;
 
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 *
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
 	int generateFirstCommand(Buffer &default_command, unsigned int device_type) override;
 
-	int statusDataValid(const Buffer &status, unsigned int device_type) override;
+	int statusDataValid(const Buffer &status, unsigned int device_type) const override;
 
-	int commandDataValid(const Buffer &command, unsigned int device_type) override;
+	int commandDataValid(const Buffer &command, unsigned int device_type) const override;
 
 	/**
 	 * @brief Constructs a buffer with the given size
@@ -64,43 +85,20 @@ public:
 
 private:
 
-	int allocate(struct buffer *buffer_pointer, size_t size_in_bytes) const;
-
-	void deallocate(struct buffer *buffer) const;
-
 	/**
-	 * @brief Constructs a buffer with the same raw c buffer as provided
+	 * @brief Constructs a buffer containing a copy of the given data
 	 *
-	 * @param buffer c buffer to be used
+	 * @param data span of bytes to copy into the buffer
 	 * @return a new Buffer object
 	 */
-	Buffer constructBufferByTakeOwnership(struct ::buffer& buffer);
-
-	std::function<void(struct buffer *)> deallocate_ {};
+	Buffer constructBuffer(std::span<const uint8_t> data);
 
 	/// Path to the module binary
 	std::filesystem::path moduleBinaryPath_ {};
 	/// Process of the module binary
 	boost::process::child moduleBinaryProcess_ {};
-
 	/// TODO find a way to not need this
-	std::mutex getModuleNumberMutex_ {};
-	std::mutex isDeviceTypeSupportedMutex_ {};
-	std::mutex sendStatusConditionMutex_ {};
-	std::mutex generateCommandMutex_ {};
-	std::mutex aggregateStatusMutex_ {};
-	std::mutex aggregateErrorMutex_ {};
-	std::mutex generateFirstCommandMutex_ {};
-	std::mutex statusDataValidMutex_ {};
-	std::mutex commandDataValidMutex_ {};
-
-	fleet_protocol::async_function_execution_definitions::ModuleFunctionExecutor aeronClient {
-		async_function_execution::Config {
-			.isProducer = true,
-			.defaultTimeout = settings::AeronClientConstants::aeron_client_default_timeout,
-		},
-		fleet_protocol::async_function_execution_definitions::moduleFunctionList
-	};
+	std::mutex tmpMutex_ {};
 };
 
 }

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
@@ -17,7 +17,7 @@ namespace bringauto::modules {
  */
 class ModuleManagerLibraryHandlerAsync : public IModuleManagerLibraryHandler {
 public:
-	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath);
+	explicit ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, int moduleNumber);
 
 	~ModuleManagerLibraryHandlerAsync() override;
 
@@ -37,7 +37,8 @@ public:
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
+	int	sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                        unsigned int device_type) const override;
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
@@ -98,7 +99,7 @@ private:
 	/// Process of the module binary
 	boost::process::child moduleBinaryProcess_ {};
 	/// TODO find a way to not need this
-	std::mutex tmpMutex_ {};
+	mutable std::mutex tmpMutex_ {};
 };
 
 }

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
@@ -20,11 +20,11 @@ public:
 	 */
 	void loadLibrary(const std::filesystem::path &path) override;
 
-	int getModuleNumber() override;
+	int getModuleNumber() const override;
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) override;
+	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
 
 	int generateCommand(Buffer &generated_command, const Buffer &new_status,
 						const Buffer &current_status, const Buffer &current_command,
@@ -33,14 +33,24 @@ public:
 	int aggregateStatus(Buffer &aggregated_status, const Buffer &current_status,
 						const Buffer &new_status, unsigned int device_type) override;
 
-	int aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 * 
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
+	int	aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
 					   unsigned int device_type) override;
 
+	/**
+	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
+	 * 
+	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
+	 */
 	int generateFirstCommand(Buffer &default_command, unsigned int device_type) override;
 
-	int statusDataValid(const Buffer &status, unsigned int device_type) override;
+	int statusDataValid(const Buffer &status, unsigned int device_type) const override;
 
-	int commandDataValid(const Buffer &command, unsigned int device_type) override;
+	int commandDataValid(const Buffer &command, unsigned int device_type) const override;
 
 	/**
 	 * @brief Constructs a buffer with the given size

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
@@ -24,7 +24,8 @@ public:
 
 	int isDeviceTypeSupported(unsigned int device_type) override;
 
-	int	sendStatusCondition(const Buffer &current_status, const Buffer &new_status, unsigned int device_type) const override;
+	int	sendStatusCondition(const Buffer& current_status, const Buffer& new_status,
+	                        unsigned int device_type) const override;
 
 	int generateCommand(Buffer &generated_command, const Buffer &new_status,
 						const Buffer &current_status, const Buffer &current_command,
@@ -35,7 +36,7 @@ public:
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
-	 * 
+	 *
 	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
 	 */
 	int	aggregateError(Buffer &error_message, const Buffer &current_error_message, const Buffer &status,
@@ -43,7 +44,7 @@ public:
 
 	/**
 	 * @short After executing the respective module function, an error might be thrown when allocating the buffer.
-	 * 
+	 *
 	 * @see fleet-protocol/lib/module_maintainer/module_gateway/include/module_manager.h
 	 */
 	int generateFirstCommand(Buffer &default_command, unsigned int device_type) override;

--- a/include/bringauto/modules/library_loader.hpp
+++ b/include/bringauto/modules/library_loader.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <filesystem>
+#include <dlfcn.h>
+
+
+
+namespace bringauto::modules::library_loader {
+
+/**
+ * @brief Load a shared library from the given path
+ *
+ * @param path path to the shared library file
+ * @return handle to the loaded library, or nullptr on failure
+ */
+void* load(const std::filesystem::path& path);
+
+}

--- a/include/bringauto/settings/Constants.hpp
+++ b/include/bringauto/settings/Constants.hpp
@@ -211,6 +211,7 @@ public:
 	inline static constexpr std::string_view CLIENT_CERT { "client-cert" };
 	inline static constexpr std::string_view CLIENT_KEY { "client-key" };
 	inline static constexpr std::string_view ALPN { "alpn" };
+	inline static constexpr std::string_view STREAM_MODE { "stream-mode" };
 
 	inline static constexpr std::string_view MODULES { "modules" };
 	inline static constexpr std::string_view AERON_CONNECTION { "aeron:ipc"};

--- a/include/bringauto/settings/Constants.hpp
+++ b/include/bringauto/settings/Constants.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <bringauto/modules/Buffer.hpp>
+
+#include <bringauto/fleet_protocol/cxx/BufferAsString.hpp>
+#include <bringauto/fleet_protocol/cxx/StringAsBuffer.hpp>
+
 #include <string_view>
 #include <chrono>
 
@@ -87,6 +92,16 @@ constexpr unsigned int max_external_commands { 3 };
 constexpr unsigned int max_external_queue_size { 500 }; 
 
 /**
+ * @brief base stream id for Aeron communication from Module Gateway to module binary
+ */
+constexpr unsigned int aeron_to_module_stream_id_base { 10000 };
+
+/**
+ * @brief base stream id for Aeron communication from module binary to Module Gateway
+ */
+constexpr unsigned int aeron_to_gateway_stream_id_base { 20000 };
+
+/**
  * @brief Constants for Mqtt communication
  */
 struct MqttConstants {
@@ -156,6 +171,7 @@ public:
 	inline static constexpr std::string_view LOG_LEVEL { "level" };
 	inline static constexpr std::string_view LOG_USE { "use" };
 	inline static constexpr std::string_view LOG_PATH { "path" };
+	inline static constexpr std::string_view LOG_UNKNOWN { "unknown" };
 
 	inline static constexpr std::string_view LOG_LEVEL_DEBUG { "DEBUG" };
 	inline static constexpr std::string_view LOG_LEVEL_INFO { "INFO" };
@@ -163,6 +179,12 @@ public:
 	inline static constexpr std::string_view LOG_LEVEL_ERROR { "ERROR" };
 	inline static constexpr std::string_view LOG_LEVEL_CRITICAL { "CRITICAL" };
 	inline static constexpr std::string_view LOG_LEVEL_INVALID { "INVALID" };
+
+	inline static constexpr std::string_view LOG_CONNECTION_STATE_NOT_INITIALIZED { "not initialized" };
+	inline static constexpr std::string_view LOG_CONNECTION_STATE_NOT_CONNECTED { "not connected" };
+	inline static constexpr std::string_view LOG_CONNECTION_STATE_CONNECTING { "connecting" };
+	inline static constexpr std::string_view LOG_CONNECTION_STATE_CONNECTED { "connected" };
+	inline static constexpr std::string_view LOG_CONNECTION_STATE_CLOSING { "closing" };
 
 	inline static constexpr std::string_view HELP { "help" };
 	inline static constexpr std::string_view PORT { "port" };
@@ -180,14 +202,19 @@ public:
 	inline static constexpr std::string_view PROTOCOL_TYPE { "protocol-type" };
 
 	inline static constexpr std::string_view MQTT { "MQTT" };
+	inline static constexpr std::string_view QUIC { "QUIC" };
 	inline static constexpr std::string_view DUMMY { "DUMMY" };
 	inline static constexpr std::string_view MQTT_SETTINGS { "mqtt-settings" };
+	inline static constexpr std::string_view QUIC_SETTINGS { "quic-settings" };
 	inline static constexpr std::string_view SSL { "ssl" };
 	inline static constexpr std::string_view CA_FILE { "ca-file" };
 	inline static constexpr std::string_view CLIENT_CERT { "client-cert" };
 	inline static constexpr std::string_view CLIENT_KEY { "client-key" };
+	inline static constexpr std::string_view ALPN { "alpn" };
 
 	inline static constexpr std::string_view MODULES { "modules" };
+	inline static constexpr std::string_view AERON_CONNECTION { "aeron:ipc"};
+	inline static constexpr std::string_view SEPARATOR { ":::" };
 };
 
 }

--- a/include/bringauto/settings/QuicSettingsParser.hpp
+++ b/include/bringauto/settings/QuicSettingsParser.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <bringauto/structures/ExternalConnectionSettings.hpp>
+
+#include <msquic.h>
+
+#include <optional>
+
+
+namespace bringauto::settings {
+	class QuicSettingsParser {
+	public:
+		static QUIC_SETTINGS parse(const structures::ExternalConnectionSettings &settings);
+
+	private:
+		static std::optional<uint64_t> getOptionalUint(
+			const structures::ExternalConnectionSettings &settings,
+			std::string_view key
+		);
+	};
+}

--- a/include/bringauto/structures/ExternalConnectionSettings.hpp
+++ b/include/bringauto/structures/ExternalConnectionSettings.hpp
@@ -17,6 +17,8 @@ enum class ProtocolType {
 	INVALID = -1,
 	/// MQTT protocol via Paho client
 	MQTT,
+	/// QUIC protocol
+	QUIC,
 	/// Dummy protocol for testing; simulates a connection without real I/O.
 	/// NOTE: receiveMessage() always returns nullptr, so any ExternalConnection
 	/// using DUMMY will never complete a connect sequence and will loop reconnecting.

--- a/include/bringauto/structures/InternalClientMessage.hpp
+++ b/include/bringauto/structures/InternalClientMessage.hpp
@@ -32,6 +32,8 @@ public:
 
 	InternalClientMessage(const InternalClientMessage& copy) = default;
 
+	InternalClientMessage& operator=(InternalClientMessage&&) noexcept = default;
+
 	/**
 	 * @brief Get internal client message
 	 *

--- a/include/bringauto/structures/ModuleLibrary.hpp
+++ b/include/bringauto/structures/ModuleLibrary.hpp
@@ -21,16 +21,9 @@ struct ModuleLibrary {
 	 * @brief Load libraries from paths
 	 *
 	 * @param libPaths paths to the libraries
-	 */
-	void loadLibraries(const std::unordered_map<int, std::filesystem::path> &libPaths);
-
-	/**
-	 * @brief Load libraries from paths
-	 *
-	 * @param libPaths paths to the libraries
 	 * @param moduleBinaryPath path to module binary for async function execution over shared memory
 	 */
-	void loadLibraries(const std::unordered_map<int, std::filesystem::path> &libPaths, const std::filesystem::path &moduleBinaryPath);
+	void loadLibraries(const std::unordered_map<int, std::filesystem::path> &libPaths, const std::filesystem::path &moduleBinaryPath = "");
 
 	/**
 	 * @brief Initialize status aggregators with context

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,6 @@
 #include <bringauto/settings/LoggerId.hpp>
 
 #include <InternalProtocol.pb.h>
-#include <libbringauto_logger/bringauto/logging/Logger.hpp>
 #include <libbringauto_logger/bringauto/logging/FileSink.hpp>
 #include <libbringauto_logger/bringauto/logging/ConsoleSink.hpp>
 

--- a/resources/config/README.md
+++ b/resources/config/README.md
@@ -28,18 +28,27 @@ Note: at least one logging sink needs to be used
 * company : company name used as identification in external connection (string)
 * vehicle-name : vehicle name used as identification in external connection (string)
 * endpoints : array of objects listing possible ways to connect to external server
-  - protocol-type : string (only mqtt is supported)
+  - protocol-type : string (only mqtt and quic are supported)
   - server-ip : ip of the external connection (string)
   - port : port of the external connection (int)
   - modules : array of integers that represent module numbers to be used on this connection
-  - mqtt-settings : **only for mqtt**
-    - ssl : if connection requires ssl, bool
-    - ca-file : public trusted certificate file name (string)
-    - client-cert : public certificate chain file name (string)
-    - client-key : private key file name (string)
 
-## Example
+#### mqtt-settings (only for MQTT)
+* ssl : if connection requires ssl, bool
+* ca-file : public trusted certificate file name (string)
+* client-cert : public certificate chain file name (string)
+* client-key : private key file name (string)
 
-[Example](./example.json)
+#### quic-settings (only for QUIC)
+* ca-file : path to the trusted CA certificate file (string)
+* client-cert : path to the client certificate file (string)
+* client-key : path to the client private key file (string)
+* alpn : Application-Layer Protocol Negotiation identifier (string), must match the ALPN configured on the server
+  
+Note: QUIC uses TLS 1.3 internally. All certificate files must be provided in a format supported by MsQuic/OpenSSL.
 
+## Examples
+
+[MQTT Example](./example.json)
+[QUIC Example](./quic_example.json)
 

--- a/resources/config/quic_example.json
+++ b/resources/config/quic_example.json
@@ -27,7 +27,9 @@
           "client-cert" : "build/certs/client.pem",
           "client-key" : "build/certs/client-key.pem",
 	      "alpn" : "sample",
-          "DisconnectTimeoutMs" : 800
+          "stream-mode": "unidirectional",
+          "DisconnectTimeoutMs" : 800,
+          "PeerUnidiStreamCount" : 100
         },
         "modules": [1,2,3]
       }

--- a/resources/config/quic_example.json
+++ b/resources/config/quic_example.json
@@ -1,0 +1,36 @@
+{
+  "logging": {
+    "console": { "level": "DEBUG", "use": true },
+    "file": { "level": "DEBUG", "use": false, "path": "./log" }
+  },
+
+  "internal-server-settings": { "port": 1636 },
+
+  "module-paths": {
+    "1": "/home/bringauto/modules/mission_module/lib/libmission-module-gateway-shared.so",
+    "2": "/home/bringauto/modules/io_module/lib/libio-module-gateway-shared.so",
+    "3": "/home/bringauto/modules/transparent_module/lib/libtransparent-module-gateway-shared.so"
+  },
+
+  "module-binary-path": "",
+
+  "external-connection" : {
+    "company" : "bringauto",
+    "vehicle-name" : "virtual_vehicle",
+    "endpoints" : [
+      {
+        "protocol-type" : "QUIC",
+        "server-ip": "127.0.0.1",
+        "port": 6121,
+        "quic-settings": {
+          "ca-file" : "build/certs/ca.pem",
+          "client-cert" : "build/certs/client.pem",
+          "client-key" : "build/certs/client-key.pem",
+	      "alpn" : "sample",
+          "DisconnectTimeoutMs" : 800
+        },
+        "modules": [1,2,3]
+      }
+    ]
+  }
+}

--- a/source/bringauto/common_utils/EnumUtils.cpp
+++ b/source/bringauto/common_utils/EnumUtils.cpp
@@ -10,6 +10,8 @@ structures::ProtocolType EnumUtils::stringToProtocolType(std::string toEnum) {
 	std::transform(toEnum.begin(), toEnum.end(), toEnum.begin(), ::toupper);
 	if(toEnum == settings::Constants::MQTT) {
 		return structures::ProtocolType::MQTT;
+	} else if(toEnum == settings::Constants::QUIC) {
+		return structures::ProtocolType::QUIC;
 	} else if(toEnum == settings::Constants::DUMMY) {
 		return structures::ProtocolType::DUMMY;
 	}

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -4,6 +4,7 @@
 #include <bringauto/external_client/connection/ConnectionState.hpp>
 #include <bringauto/external_client/connection/communication/MqttCommunication.hpp>
 #include <bringauto/external_client/connection/communication/DummyCommunication.hpp>
+#include <bringauto/external_client/connection/communication/QuicCommunication.hpp>
 #include <bringauto/settings/LoggerId.hpp>
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
@@ -96,6 +97,11 @@ void ExternalClient::initConnections() {
 		switch(connectionSettings.protocolType) {
 			case structures::ProtocolType::MQTT:
 				communicationChannel = std::make_shared<connection::communication::MqttCommunication>(
+					connectionSettings, context_->settings->company, context_->settings->vehicleName
+				);
+				break;
+			case structures::ProtocolType::QUIC:
+				communicationChannel = std::make_shared<connection::communication::QuicCommunication>(
 					connectionSettings, context_->settings->company, context_->settings->vehicleName
 				);
 				break;

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -12,7 +12,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 
-
 namespace bringauto::external_client {
 
 namespace ip = InternalProtocol;

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -188,6 +188,7 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 
 void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
                                               std::atomic<bool> &connectDone) {
+	std::optional<structures::InternalClientMessage> deferredDisconnect;
 	while (!connectDone.load() && !context_->ioContext.stopped() &&
 	       connection.getState() != connection::ConnectionState::CONNECTED) {
 		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
@@ -196,6 +197,17 @@ void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &con
 		// Re-check after unblocking: connection may have finished while we were waiting.
 		// Without this, we could pop and feed fillErrorAggregator after clear_error_aggregator already ran.
 		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;
+		}
+		// Do not drain disconnect messages — they must reach handleAggregatedMessages
+		// so the device is properly removed from connectedDevices_ via deleteConnectedDevice().
+		// Consuming a disconnect here would leave the device in connectedDevices_ after the
+		// connect sequence, causing the gateway and server to lose sync on device state.
+		// Pop it into deferredDisconnect so any messages after it can still be processed,
+		// then re-push it after the loop so handleAggregatedMessages sees it.
+		if (toExternalQueue_->front().disconnected()) {
+			deferredDisconnect = std::move(toExternalQueue_->front());
+			toExternalQueue_->pop();
 			break;
 		}
 		const auto internalMessage = std::move(toExternalQueue_->front());
@@ -207,6 +219,9 @@ void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &con
 			sendStatus(internalMessage);
 		}
 	}
+	if (deferredDisconnect.has_value()) {
+		toExternalQueue_->pushAndNotify(std::move(*deferredDisconnect));
+	}
 }
 
 void ExternalClient::startExternalConnectSequence(connection::ExternalConnection &connection) {
@@ -214,6 +229,11 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	insideConnectSequence_ = true;
 
 	while(not toExternalQueue_->empty()) {
+		// Do not consume disconnect messages — they must reach handleAggregatedMessages
+		// so the device is properly removed via sendStatus(..., DISCONNECT).
+		if(toExternalQueue_->front().disconnected()) {
+			break;
+		}
 		auto internalMessage = std::move(toExternalQueue_->front());
 		toExternalQueue_->pop();
 		const auto &deviceStatus = internalMessage.getMessage().devicestatus();

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -188,12 +188,15 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 
 void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
                                               std::atomic<bool> &connectDone) {
-	while (!connectDone.load() && !context_->ioContext.stopped()) {
-		if (connection.getState() == connection::ConnectionState::CONNECTED) {
-			break;  // success path: stop filling to avoid racing with clear_error_aggregator
-		}
+	while (!connectDone.load() && !context_->ioContext.stopped() &&
+	       connection.getState() != connection::ConnectionState::CONNECTED) {
 		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
 			continue;
+		}
+		// Re-check after unblocking: connection may have finished while we were waiting.
+		// Without this, we could pop and feed fillErrorAggregator after clear_error_aggregator already ran.
+		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;
 		}
 		const auto internalMessage = std::move(toExternalQueue_->front());
 		toExternalQueue_->pop();

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -304,7 +304,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(connection), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(connection), true));
 			settings::Logger::logDebug("Reconnect timer expired");
 		});
 	}

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -186,6 +186,26 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 	return true;
 }
 
+void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
+                                              std::atomic<bool> &connectDone) {
+	while (!connectDone.load() && !context_->ioContext.stopped()) {
+		if (connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;  // success path: stop filling to avoid racing with clear_error_aggregator
+		}
+		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
+			continue;
+		}
+		const auto internalMessage = std::move(toExternalQueue_->front());
+		toExternalQueue_->pop();
+		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
+		if (connection.isModuleSupported(deviceStatus.device().module())) {
+			connection.fillErrorAggregator(deviceStatus);
+		} else {
+			sendStatus(internalMessage);
+		}
+	}
+}
+
 void ExternalClient::startExternalConnectSequence(connection::ExternalConnection &connection) {
 	settings::Logger::logInfo("Initializing new connection");
 	insideConnectSequence_ = true;
@@ -240,30 +260,16 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	// continue to be fed through fillErrorAggregator. Without this, the
 	// aggregate_error invoke count falls out of sync with the module's predictive
 	// check in sendStatusCondition, causing spurious test failures.
-	std::atomic<bool> connectDone { false };
+	std::atomic connectDone { false };
 	int connectResult = NOT_OK;
 	std::jthread connectThread([&]() {
 		connectResult = connection.initializeConnection(connectedDevices);
-		connectDone.store(true, std::memory_order_release);
+		connectDone.store(true);
 	});
 
-	while (!connectDone.load(std::memory_order_acquire) && not context_->ioContext.stopped()) {
-		if (connection.getState() == connection::ConnectionState::CONNECTED) {
-			break;  // success path: stop filling to avoid racing with clear_error_aggregator
-		}
-		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
-			continue;
-		}
-		const auto internalMessage = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
-		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
-		if (connection.isModuleSupported(deviceStatus.device().module())) {
-			connection.fillErrorAggregator(deviceStatus);
-		} else {
-			sendStatus(internalMessage);
-		}
-	}
-	if (context_->ioContext.stopped() && !connectDone.load(std::memory_order_acquire)) {
+	drainQueueDuringConnect(connection, connectDone);
+
+	if (context_->ioContext.stopped() && !connectDone.load()) {
 		// Interrupt initializeConnection() so the thread can finish promptly.
 		// closeConnection() fires SHUTDOWN_COMPLETE which notifies inboundCv_,
 		// waking any blocked receiveMessage() call.
@@ -271,7 +277,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	}
 	connectThread.join();
 
-	if(connectResult != 0 && not context_->ioContext.stopped()) {
+	if(connectResult != 0 && !context_->ioContext.stopped()) {
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <atomic>
+
 
 namespace bringauto::external_client {
 
@@ -233,7 +235,43 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	}
 	connection.fillErrorAggregatorWithNotAckedStatuses();
 
-	if(connection.initializeConnection(connectedDevices) != 0 && not context_->ioContext.stopped()) {
+	// Run initializeConnection on a background thread so that statuses arriving
+	// during a long connect attempt (e.g. QUIC 5-second receive_message_timeout)
+	// continue to be fed through fillErrorAggregator. Without this, the
+	// aggregate_error invoke count falls out of sync with the module's predictive
+	// check in sendStatusCondition, causing spurious test failures.
+	std::atomic<bool> connectDone { false };
+	int connectResult = NOT_OK;
+	std::jthread connectThread([&]() {
+		connectResult = connection.initializeConnection(connectedDevices);
+		connectDone.store(true, std::memory_order_release);
+	});
+
+	while (!connectDone.load(std::memory_order_acquire) && not context_->ioContext.stopped()) {
+		if (connection.getState() == connection::ConnectionState::CONNECTED) {
+			break;  // success path: stop filling to avoid racing with clear_error_aggregator
+		}
+		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
+			continue;
+		}
+		const auto internalMessage = std::move(toExternalQueue_->front());
+		toExternalQueue_->pop();
+		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
+		if (connection.isModuleSupported(deviceStatus.device().module())) {
+			connection.fillErrorAggregator(deviceStatus);
+		} else {
+			sendStatus(internalMessage);
+		}
+	}
+	if (context_->ioContext.stopped() && !connectDone.load(std::memory_order_acquire)) {
+		// Interrupt initializeConnection() so the thread can finish promptly.
+		// closeConnection() fires SHUTDOWN_COMPLETE which notifies inboundCv_,
+		// waking any blocked receiveMessage() call.
+		connection.cancelPendingConnect();
+	}
+	connectThread.join();
+
+	if(connectResult != 0 && not context_->ioContext.stopped()) {
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -147,7 +147,9 @@ int ExternalConnection::initializeConnection(const std::vector<structures::Devic
 int ExternalConnection::connectMessageHandle(const std::vector<structures::DeviceIdentification> &devices) {
 	generateSessionId();
 
-	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_, company_, vehicleName_,
+	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_,
+																				   context_->settings->company,
+																				   context_->settings->vehicleName,
 																				   devices);
 	if(not communicationChannel_->sendMessage(&connectMessage)){
 		log::logError("Communication client couldn't send any message");

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -263,6 +263,10 @@ u_int32_t ExternalConnection::getNextStatusCounter() {
 	return ++clientMessageCounter_;
 }
 
+void ExternalConnection::cancelPendingConnect() {
+	communicationChannel_->closeConnection();
+}
+
 void ExternalConnection::deinitializeConnection(bool completeDisconnect = false) {
 	state_.exchange(ConnectionState::NOT_INITIALIZED);
 	clientMessageCounter_ = 0;

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -346,6 +346,11 @@ void ExternalConnection::receivingHandlerLoop() {
 			continue;
 		}
 		const auto serverMessage = communicationChannel_->receiveMessage();
+		if(communicationChannel_->consumeServerDisconnectNotification()) {
+			log::logInfo("External server sent disconnect notification, triggering immediate reconnect");
+			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			return;
+		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
 			continue;
 		}

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -137,8 +137,11 @@ int ExternalConnection::initializeConnection(const std::vector<structures::Devic
 	}
 	listeningThread = std::jthread(&ExternalConnection::receivingHandlerLoop, this);
 	state_.exchange(ConnectionState::CONNECTED);
-	for(auto &[moduleNum, errorAggregator]: errorAggregators_) {
-		errorAggregator.clear_error_aggregator();
+	{
+		std::lock_guard lock(errorAggregatorsMutex_);
+		for(auto &[moduleNum, errorAggregator]: errorAggregators_) {
+			errorAggregator.clear_error_aggregator();
+		}
 	}
 	log::logInfo("Connect sequence successful. Server {}:{}", settings_.serverIp, settings_.port);
 	return OK;
@@ -182,21 +185,25 @@ int ExternalConnection::statusMessageHandle(const std::vector<structures::Device
 		modules::Buffer errorBuffer {};
 		modules::Buffer statusBuffer {};
 
-		const auto &lastErrorStatusRc = errorAggregators_[deviceModule].get_error(errorBuffer, deviceIdentification);
-		if(lastErrorStatusRc == DEVICE_NOT_REGISTERED) {
-			log::logError("Device is not registered in error aggregator: {} {}",
-				deviceIdentification.getDeviceRole(),
-				deviceIdentification.getDeviceName());
-			return DEVICE_NOT_REGISTERED;
+		{
+			std::lock_guard lock(errorAggregatorsMutex_);
+			const auto &lastErrorStatusRc = errorAggregators_[deviceModule].get_error(errorBuffer, deviceIdentification);
+			if(lastErrorStatusRc == DEVICE_NOT_REGISTERED) {
+				log::logError("Device is not registered in error aggregator: {} {}",
+					deviceIdentification.getDeviceRole(),
+					deviceIdentification.getDeviceName());
+				return DEVICE_NOT_REGISTERED;
+			}
+
+			const int lastStatusRc = errorAggregators_[deviceModule].get_last_status(statusBuffer, deviceIdentification);
+			if(lastStatusRc != OK) {
+				log::logError("Cannot obtain status for device: {} {}",
+					deviceIdentification.getDeviceRole(),
+					deviceIdentification.getDeviceName());
+				return NO_MESSAGE_AVAILABLE;
+			}
 		}
 
-		const int lastStatusRc = errorAggregators_[deviceModule].get_last_status(statusBuffer, deviceIdentification);
-		if(lastStatusRc != OK) {
-			log::logError("Cannot obtain status for device: {} {}",
-				deviceIdentification.getDeviceRole(),
-				deviceIdentification.getDeviceName());
-			return NO_MESSAGE_AVAILABLE;
-		}
 		auto deviceStatus = common_utils::ProtobufUtils::createDeviceStatus(deviceIdentification, statusBuffer);
 		sendStatus(deviceStatus, ExternalProtocol::Status_DeviceState_CONNECTING, errorBuffer);
 	}
@@ -369,7 +376,7 @@ u_int32_t ExternalConnection::getCommandCounter(const ExternalProtocol::Command 
 	return command.messagecounter();
 }
 
-void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
+void ExternalConnection::fillErrorAggregatorWithNotAckedStatusesImpl() {
 	for(const auto &notAckedStatus: sentMessagesHandler_->getNotAckedStatuses()) {
 		const auto &device = notAckedStatus->getDevice();
 
@@ -391,14 +398,20 @@ void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
 	sentMessagesHandler_->clearAll();
 }
 
+void ExternalConnection::fillErrorAggregatorWithNotAckedStatuses() {
+	std::lock_guard lock(errorAggregatorsMutex_);
+	fillErrorAggregatorWithNotAckedStatusesImpl();
+}
+
 void ExternalConnection::fillErrorAggregator(const InternalProtocol::DeviceStatus &deviceStatus) {
 	int moduleNum = deviceStatus.device().module();
+	std::lock_guard lock(errorAggregatorsMutex_);
 	const auto it = errorAggregators_.find(moduleNum);
 	if(it == errorAggregators_.end()) {
 		log::logError("Module with module number {} does no exists", moduleNum);
 		return;
 	}
-	fillErrorAggregatorWithNotAckedStatuses();
+	fillErrorAggregatorWithNotAckedStatusesImpl();
 	const auto &statusData = deviceStatus.statusdata();
 	const auto statusBuffer = moduleLibrary_.moduleLibraryHandlers.at(moduleNum)->constructBuffer(
 		statusData.size());

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -264,6 +264,7 @@ u_int32_t ExternalConnection::getNextStatusCounter() {
 }
 
 void ExternalConnection::cancelPendingConnect() {
+	communicationChannel_->cancelReceive();
 	communicationChannel_->closeConnection();
 }
 

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -24,7 +24,7 @@ ExternalConnection::ExternalConnection(const std::shared_ptr<structures::GlobalC
 		commandQueue_ { commandQueue },
 		reconnectQueue_ { reconnectQueue } {
 	sentMessagesHandler_ = std::make_unique<messages::SentMessagesHandler>(context, [this]() {
-		reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+		reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 	});
 }
 
@@ -348,7 +348,7 @@ void ExternalConnection::receivingHandlerLoop() {
 		const auto serverMessage = communicationChannel_->receiveMessage();
 		if(communicationChannel_->consumeServerDisconnectNotification()) {
 			log::logInfo("External server sent disconnect notification, triggering immediate reconnect");
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 			return;
 		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
@@ -358,7 +358,7 @@ void ExternalConnection::receivingHandlerLoop() {
 			const auto &command = serverMessage->command();
 			log::logDebug("Handling COMMAND messageCounter={}", command.messagecounter());
 			if(handleCommand(command) != OK) {
-				reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+				reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 				return;
 			}
 		} else if(serverMessage->has_statusresponse()) {
@@ -370,7 +370,7 @@ void ExternalConnection::receivingHandlerLoop() {
 			}
 		} else {
 			log::logError("Received message with unexpected type(connect response), closing connection");
-			reconnectQueue_->push(structures::ReconnectQueueItem(std::ref(*this), true));
+			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 			return;
 		}
 

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -29,6 +29,7 @@ MqttCommunication::~MqttCommunication() {
 void MqttCommunication::setProperties(const std::string& company, const std::string& vehicleName) {
 	publishTopic_ = createPublishTopic(company, vehicleName);
 	subscribeTopic_ = createSubscribeTopic(company, vehicleName);
+	serverDisconnectTopic_ = createServerDisconnectTopic(company, vehicleName);
 	clientId_ = createClientId(company, vehicleName);
 
 	serverAddress_ = {
@@ -82,6 +83,8 @@ void MqttCommunication::connect() {
 
 	const auto substok = client_->subscribe(subscribeTopic_, qos);
 	substok->wait();
+	const auto disctok = client_->subscribe(serverDisconnectTopic_, qos);
+	disctok->wait();
 }
 
 bool MqttCommunication::sendMessage(ExternalProtocol::ExternalClient* message) {
@@ -111,6 +114,12 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 		return nullptr;
 	}
 
+	if(msg->get_topic() == serverDisconnectTopic_) {
+		settings::Logger::logInfo("Received server disconnect notification on topic '{}'", serverDisconnectTopic_);
+		serverDisconnectPending_.store(true);
+		return nullptr;
+	}
+
 	auto ptr = std::make_shared<ExternalProtocol::ExternalServer>();
 	if (!ptr->ParseFromArray(msg->get_payload_str().c_str(), static_cast<int>(msg->get_payload_str().size()))) {
 		settings::Logger::logError("Failed to parse protobuf message from external server");
@@ -119,13 +128,19 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 	return ptr;
 }
 
+bool MqttCommunication::consumeServerDisconnectNotification() {
+	return serverDisconnectPending_.exchange(false);
+}
+
 void MqttCommunication::closeConnection() {
 	std::lock_guard<std::mutex> lock(receiveMessageMutex_);
+	serverDisconnectPending_.store(false);
 	if(not client_) {
 		return;
 	}
 	if(client_->is_connected()) {
 		client_->unsubscribe(subscribeTopic_);
+		client_->unsubscribe(serverDisconnectTopic_);
 		client_->disconnect();
 	}
 	client_.reset();
@@ -141,6 +156,10 @@ std::string MqttCommunication::createPublishTopic(const std::string &company, co
 
 std::string MqttCommunication::createSubscribeTopic(const std::string &company, const std::string &vehicleName) {
 	return createClientId(company, vehicleName) + std::string("/external_server");
+}
+
+std::string MqttCommunication::createServerDisconnectTopic(const std::string &company, const std::string &vehicleName) {
+	return createClientId(company, vehicleName) + std::string("/external_server_disconnect");
 }
 
 

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -20,7 +20,8 @@ namespace bringauto::external_client::connection::communication {
 		                                                                       settings::Constants::CLIENT_KEY)),
 	                                                                       caFile_(getProtocolSettingsString(
 		                                                                       settings,
-		                                                                       settings::Constants::CA_FILE)) {
+		                                                                       settings::Constants::CA_FILE)),
+	                                                                       streamMode_(parseStreamMode(settings)) {
 		alpnBuffer_.Buffer = reinterpret_cast<uint8_t *>(alpn_.data());
 		alpnBuffer_.Length = static_cast<uint32_t>(alpn_.size());
 
@@ -62,7 +63,7 @@ namespace bringauto::external_client::connection::communication {
 		);
 
 		if (QUIC_FAILED(status)) {
-			settings::Logger::logError("ConnectionOpen failed (status=0x{:x})", status);
+			settings::Logger::logError("ConnectionStart failed (status=0x{:x})", status);
 			return;
 		}
 
@@ -88,15 +89,29 @@ namespace bringauto::external_client::connection::communication {
 	std::shared_ptr<ExternalProtocol::ExternalServer> QuicCommunication::receiveMessage() {
 		std::unique_lock lock(inboundMutex_);
 
+		// Wait for a message or transition out of allowed states
+		// Explicitly allow waiting during CONNECTING, CLOSING, and CONNECTED states
+		// This whitelist approach is safe if new states are added in the future
 		if (!inboundCv_.wait_for(
 			lock,
 			settings::receive_message_timeout,
-			[this] { return !inboundQueue_.empty() || connectionState_.load() != ConnectionState::CONNECTED; }
+			[this] {
+				auto state = connectionState_.load();
+				return !inboundQueue_.empty() ||
+				       (state != ConnectionState::CONNECTING &&
+				        state != ConnectionState::CLOSING &&
+				        state != ConnectionState::CONNECTED);
+			}
 		)) {
 			return nullptr;
 		}
 
-		if (connectionState_.load() != ConnectionState::CONNECTED || inboundQueue_.empty()) {
+		// Check if we stopped waiting due to invalid state or empty queue
+		auto state = connectionState_.load();
+		if ((state != ConnectionState::CONNECTING &&
+		     state != ConnectionState::CLOSING &&
+		     state != ConnectionState::CONNECTED) ||
+		    inboundQueue_.empty()) {
 			return nullptr;
 		}
 
@@ -230,7 +245,13 @@ namespace bringauto::external_client::connection::communication {
 
 	void QuicCommunication::sendViaQuicStream(const ExternalProtocol::ExternalClient& message) {
 		HQUIC stream{nullptr};
-		if (QUIC_FAILED(quic_->StreamOpen(connection_, QUIC_STREAM_OPEN_FLAG_NONE, streamCallback, this, &stream))) {
+
+		QUIC_STREAM_OPEN_FLAGS flags = streamMode_ == StreamMode::Unidirectional
+			                               ? QUIC_STREAM_OPEN_FLAG_UNIDIRECTIONAL
+			                               : QUIC_STREAM_OPEN_FLAG_NONE;
+
+		if (QUIC_FAILED(
+			quic_->StreamOpen(connection_, flags, streamCallback, this, &stream))) {
 			settings::Logger::logError("[quic] StreamOpen failed");
 			return;
 		}
@@ -271,7 +292,7 @@ namespace bringauto::external_client::connection::communication {
 		settings::Logger::logDebug("[quic] [stream {}] Message sent", streamId ? *streamId : 0);
 	}
 
-	QUIC_STATUS QUIC_API QuicCommunication::connectionCallback(HQUIC connection, void *context, // NOSONAR - void* required by QUIC_CONNECTION_CALLBACK C API
+	QUIC_STATUS QUIC_API QuicCommunication::connectionCallback(HQUIC connection, void *context,
 	                                                           QUIC_CONNECTION_EVENT *event) {
 		auto *self = static_cast<QuicCommunication *>(context);
 
@@ -287,6 +308,23 @@ namespace bringauto::external_client::connection::communication {
 					self->senderThread_ = std::jthread(&QuicCommunication::senderLoop, self);
 					self->outboundCv_.notify_all();
 				}
+				break;
+			}
+
+			/// Fired when peer open new stream on connection, stream handler need to be def
+			case QUIC_CONNECTION_EVENT_PEER_STREAM_STARTED: {
+				auto streamId = self->getStreamId(event->PEER_STREAM_STARTED.Stream);
+
+				settings::Logger::logDebug(
+					"[quic] [stream {}] Peer stream started",
+					streamId.value_or(0)
+				);
+
+				self->quic_->SetCallbackHandler(event->PEER_STREAM_STARTED.Stream,
+				                                reinterpret_cast<void *>(streamCallback), // NOSONAR - MsQuic C API requires passing function pointer as void*
+				                                context);
+
+				self->quic_->StreamReceiveSetEnabled(event->PEER_STREAM_STARTED.Stream, TRUE);
 				break;
 			}
 
@@ -325,7 +363,7 @@ namespace bringauto::external_client::connection::communication {
 		return QUIC_STATUS_SUCCESS;
 	}
 
-	QUIC_STATUS QUIC_API QuicCommunication::streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) { // NOSONAR - void* required by QUIC_STREAM_CALLBACK C API
+	QUIC_STATUS QUIC_API QuicCommunication::streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) {
 		auto *self = static_cast<QuicCommunication *>(context);
 		auto streamId = self->getStreamId(stream);
 
@@ -487,16 +525,39 @@ namespace bringauto::external_client::connection::communication {
 
 	std::string QuicCommunication::getProtocolSettingsString(
 		const structures::ExternalConnectionSettings &settings,
-		std::string_view key
+		std::string_view key,
+		std::string defaultValue
 	) {
-		const auto &raw = settings.protocolSettings.at(std::string(key));
-
-		if (nlohmann::json::accept(raw)) {
-			auto j = nlohmann::json::parse(raw);
-			if (j.is_string()) {
-				return j.get<std::string>();
-			}
+		const auto it = settings.protocolSettings.find(std::string(key));
+		if (it == settings.protocolSettings.end()) {
+			settings::Logger::logWarning("[quic] Protocol setting '{}' not found, using default", key);
+			return defaultValue;
 		}
-		return raw;
+
+		const auto &raw = it->second;
+
+		try {
+			if (nlohmann::json::accept(raw)) {
+				auto j = nlohmann::json::parse(raw);
+				if (j.is_string()) {
+					return j.get<std::string>();
+				}
+			}
+			return raw;
+		} catch (const nlohmann::json::exception &) {
+			settings::Logger::logWarning("[quic] Protocol setting '{}' contains invalid JSON, using default", key);
+			return defaultValue;
+		}
+	}
+
+	QuicCommunication::StreamMode QuicCommunication::parseStreamMode(
+		const structures::ExternalConnectionSettings &settings
+	) {
+		const std::string mode = getProtocolSettingsString(settings, settings::Constants::STREAM_MODE);
+
+		if (mode == "unidirectional" || mode == "unidir")
+			return StreamMode::Unidirectional;
+
+		return StreamMode::Bidirectional;
 	}
 }

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -1,0 +1,502 @@
+#include <bringauto/common_utils/EnumUtils.hpp>
+#include <bringauto/external_client/connection/communication/QuicCommunication.hpp>
+#include <bringauto/settings/Constants.hpp>
+#include <bringauto/settings/LoggerId.hpp>
+#include <bringauto/settings/QuicSettingsParser.hpp>
+
+
+namespace bringauto::external_client::connection::communication {
+	QuicCommunication::QuicCommunication(const structures::ExternalConnectionSettings &settings,
+	                                     const std::string &company,
+	                                     const std::string &vehicleName) : ICommunicationChannel(settings),
+	                                                                       alpn_(getProtocolSettingsString(
+		                                                                       settings,
+		                                                                       settings::Constants::ALPN)),
+	                                                                       certFile_(getProtocolSettingsString(
+		                                                                       settings,
+		                                                                       settings::Constants::CLIENT_CERT)),
+	                                                                       keyFile_(getProtocolSettingsString(
+		                                                                       settings,
+		                                                                       settings::Constants::CLIENT_KEY)),
+	                                                                       caFile_(getProtocolSettingsString(
+		                                                                       settings,
+		                                                                       settings::Constants::CA_FILE)) {
+		alpnBuffer_.Buffer = reinterpret_cast<uint8_t *>(alpn_.data());
+		alpnBuffer_.Length = static_cast<uint32_t>(alpn_.size());
+
+		loadMsQuic();
+		initRegistration();
+		initConfiguration();
+
+		settings::Logger::logInfo("[quic] Initialize QUIC communication to {}:{} for {}/{}", settings.serverIp,
+		                          settings.port, company, vehicleName);
+	}
+
+	QuicCommunication::~QuicCommunication() {
+		stop();
+	}
+
+	void QuicCommunication::initializeConnection() {
+		settings::Logger::logDebug("[quic] Connecting to server when {}",
+		                           common_utils::EnumUtils::connectionStateToString(connectionState_));
+
+		ConnectionState expected = ConnectionState::NOT_CONNECTED;
+		if (!connectionState_.
+			compare_exchange_strong(expected, ConnectionState::CONNECTING, std::memory_order_acq_rel)) {
+			settings::Logger::logError("Connection already in progress or established");
+			return;
+		}
+
+		QUIC_STATUS status = quic_->ConnectionOpen(registration_, connectionCallback, this, &connection_);
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("ConnectionOpen failed (status=0x{:x})", status);
+			return;
+		}
+
+		status = quic_->ConnectionStart(
+			connection_,
+			config_,
+			QUIC_ADDRESS_FAMILY_INET,
+			settings_.serverIp.c_str(),
+			settings_.port
+		);
+
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("ConnectionOpen failed (status=0x{:x})", status);
+			return;
+		}
+
+		connectionState_ = ConnectionState::CONNECTING;
+	}
+
+	bool QuicCommunication::sendMessage(ExternalProtocol::ExternalClient *message) {
+		if (connectionState_.load() == ConnectionState::NOT_CONNECTED) {
+			settings::Logger::logWarning("[quic] Connection not established, cannot send message");
+			return false;
+		}
+
+		{
+			auto copy = std::make_unique<ExternalProtocol::ExternalClient>(*message);
+			std::lock_guard lock(outboundMutex_);
+			outboundQueue_.push(std::move(copy));
+		}
+		settings::Logger::logDebug("[quic] Notifying sender thread about enqueued message");
+		outboundCv_.notify_one();
+		return true;
+	}
+
+	std::shared_ptr<ExternalProtocol::ExternalServer> QuicCommunication::receiveMessage() {
+		std::unique_lock lock(inboundMutex_);
+
+		if (!inboundCv_.wait_for(
+			lock,
+			settings::receive_message_timeout,
+			[this] { return !inboundQueue_.empty() || connectionState_.load() != ConnectionState::CONNECTED; }
+		)) {
+			return nullptr;
+		}
+
+		if (connectionState_.load() != ConnectionState::CONNECTED || inboundQueue_.empty()) {
+			return nullptr;
+		}
+
+		auto msg = inboundQueue_.front();
+		inboundQueue_.pop();
+		return msg;
+	}
+
+	void QuicCommunication::loadMsQuic() {
+		QUIC_STATUS status = MsQuicOpen2(&quic_);
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("[quic] Failed to open QUIC; QUIC_STATUS => {:x}", status);
+			return;
+		}
+	}
+
+	constexpr auto quicRegistrationAppName = "module-gateway-quic-client";
+
+	void QuicCommunication::initRegistration() {
+		QUIC_REGISTRATION_CONFIG config{};
+		config.AppName = quicRegistrationAppName;
+		config.ExecutionProfile = QUIC_EXECUTION_PROFILE_LOW_LATENCY;
+
+		QUIC_STATUS status = quic_->RegistrationOpen(&config, &registration_);
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("[quic] Failed to open QUIC registration; QUIC_STATUS => {:x}", status);
+			return;
+		}
+	}
+
+	void QuicCommunication::initConfiguration() {
+		configurationOpen();
+
+		QUIC_CERTIFICATE_FILE certificate{};
+		certificate.CertificateFile = certFile_.c_str();
+		certificate.PrivateKeyFile = keyFile_.c_str();
+
+		QUIC_CREDENTIAL_CONFIG credential{};
+		credential.Type = QUIC_CREDENTIAL_TYPE_CERTIFICATE_FILE;
+		credential.Flags = QUIC_CREDENTIAL_FLAG_CLIENT | QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE;
+		credential.CertificateFile = &certificate;
+		credential.CaCertificateFile = caFile_.c_str();
+
+		configurationLoadCredential(&credential);
+	}
+
+	void QuicCommunication::configurationOpen() {
+		const QUIC_SETTINGS settings = settings::QuicSettingsParser::parse(settings_);
+		const uint32_t settingsSize = sizeof(QUIC_SETTINGS);
+
+		QUIC_STATUS status = quic_->ConfigurationOpen(
+			registration_,
+			&alpnBuffer_,
+			1,
+			&settings,
+			settingsSize,
+			nullptr,
+			&config_
+		);
+
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("[quic] Failed to open QUIC configuration; QUIC_STATUS => {:x}", status);
+			return;
+		}
+	}
+
+	void QuicCommunication::configurationLoadCredential(const QUIC_CREDENTIAL_CONFIG *credential) const {
+		const QUIC_STATUS status = quic_->ConfigurationLoadCredential(config_, credential);
+		if (QUIC_FAILED(status)) {
+			settings::Logger::logError("[quic] Failed to load QUIC credential; QUIC_STATUS => {:x}", status);
+			return;
+		}
+	}
+
+	void QuicCommunication::closeConnection() {
+		if (!connection_) {
+			return;
+		}
+
+		quic_->ConnectionShutdown(connection_, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
+
+		/// Asynchronously waiting for QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event, then continue in connectionCallback
+	}
+
+	void QuicCommunication::closeConfiguration() {
+		if (config_) {
+			quic_->ConfigurationClose(config_);
+		}
+
+		config_ = nullptr;
+	}
+
+	void QuicCommunication::closeRegistration() {
+		if (registration_) {
+			quic_->RegistrationClose(registration_);
+		}
+
+		registration_ = nullptr;
+	}
+
+	void QuicCommunication::closeMsQuic() {
+		if (quic_) {
+			MsQuicClose(quic_);
+		}
+
+		quic_ = nullptr;
+	}
+
+	void QuicCommunication::stop() {
+		QuicCommunication::closeConnection();
+		closeConfiguration();
+		closeRegistration();
+		closeMsQuic();
+
+		inboundCv_.notify_all();
+		outboundCv_.notify_all();
+
+		settings::Logger::logInfo("[quic] Connection stopped");
+	}
+
+	void QuicCommunication::onMessageDecoded(
+		std::shared_ptr<ExternalProtocol::ExternalServer> msg
+	) {
+		{
+			std::scoped_lock lock(inboundMutex_);
+			inboundQueue_.push(std::move(msg));
+		}
+		settings::Logger::logDebug("[quic] Notifying receiver thread about dequeued message");
+		inboundCv_.notify_one();
+	}
+
+	void QuicCommunication::sendViaQuicStream(const ExternalProtocol::ExternalClient& message) {
+		HQUIC stream{nullptr};
+		if (QUIC_FAILED(quic_->StreamOpen(connection_, QUIC_STREAM_OPEN_FLAG_NONE, streamCallback, this, &stream))) {
+			settings::Logger::logError("[quic] StreamOpen failed");
+			return;
+		}
+
+		const size_t size = message.ByteSizeLong();
+		auto sendBuffer = std::make_unique<SendBuffer>(size);
+
+		if (!message.SerializeToArray(sendBuffer->storage.data(), static_cast<int>(size))) {
+			settings::Logger::logError("[quic] Message serialization failed");
+			return;
+		}
+
+		const SendBuffer *raw = sendBuffer.get();
+		const QUIC_BUFFER *quicBuf = &raw->buffer;
+		SendBuffer *quicBufContext = sendBuffer.release();
+
+		const QUIC_STATUS status = quic_->StreamSend(
+			stream,
+			quicBuf,
+			1,
+			/**
+			 * START => Simulates quic_->StreamStart before send
+			 * FIN => Simulates quic_->StreamShutdown after send
+			 */
+			QUIC_SEND_FLAG_START | QUIC_SEND_FLAG_FIN,
+			quicBufContext
+		);
+
+		if (QUIC_FAILED(status)) {
+			std::unique_ptr<SendBuffer> reclaim{quicBufContext};
+
+			quic_->StreamShutdown(stream, QUIC_STREAM_SHUTDOWN_FLAG_ABORT, 0);
+			settings::Logger::logError("[quic] Failed to send QUIC stream; QUIC_STATUS => {:x}", status);
+			return;
+		}
+
+		auto streamId = getStreamId(stream);
+		settings::Logger::logDebug("[quic] [stream {}] Message sent", streamId ? *streamId : 0);
+	}
+
+	QUIC_STATUS QUIC_API QuicCommunication::connectionCallback(HQUIC connection, void *context, // NOSONAR - void* required by QUIC_CONNECTION_CALLBACK C API
+	                                                           QUIC_CONNECTION_EVENT *event) {
+		auto *self = static_cast<QuicCommunication *>(context);
+
+		switch (event->Type) {
+			/// Fired when the QUIC handshake is complete and the connection is ready
+			/// for stream creation and data transfer.
+			case QUIC_CONNECTION_EVENT_CONNECTED: {
+				settings::Logger::logInfo("[quic] Connected to server");
+
+				auto expected = ConnectionState::CONNECTING;
+				if (self->connectionState_.compare_exchange_strong(expected, ConnectionState::CONNECTED)) {
+					/// Start sender thread only after connection is fully established
+					self->senderThread_ = std::jthread(&QuicCommunication::senderLoop, self);
+					self->outboundCv_.notify_all();
+				}
+				break;
+			}
+
+			/// Final notification that the connection has been fully shut down.
+			/// This is the last event delivered for the connection handle.
+			case QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE: {
+				settings::Logger::logInfo("[quic] Connection shutdown complete");
+
+				self->connectionState_ = ConnectionState::NOT_CONNECTED;
+				self->outboundCv_.notify_all();
+
+				if (self->senderThread_.joinable()) {
+					self->senderThread_.request_stop();
+				}
+
+				self->quic_->ConnectionClose(connection);
+				self->connection_ = nullptr;
+				break;
+			}
+
+			/// Peer or transport initiated connection shutdown (error or graceful close).
+			/// Further sends may fail after this event.
+			case QUIC_CONNECTION_EVENT_SHUTDOWN_INITIATED_BY_PEER: {
+				settings::Logger::logWarning("[quic] Connection shutdown initiated by peer");
+				self->connectionState_ = ConnectionState::CLOSING;
+				break;
+			}
+
+			default: {
+				settings::Logger::logDebug("[quic] Unhandled connection event 0x{:x}",
+				                           static_cast<unsigned>(event->Type));
+				break;
+			}
+		}
+
+		return QUIC_STATUS_SUCCESS;
+	}
+
+	QUIC_STATUS QUIC_API QuicCommunication::streamCallback(HQUIC stream, void *context, QUIC_STREAM_EVENT *event) { // NOSONAR - void* required by QUIC_STREAM_CALLBACK C API
+		auto *self = static_cast<QuicCommunication *>(context);
+		auto streamId = self->getStreamId(stream);
+
+		switch (event->Type) {
+			/// Raised when the peer sends stream data and MsQuic delivers received bytes to the application.
+			case QUIC_STREAM_EVENT_RECEIVE: {
+				if (event->RECEIVE.BufferCount == 0) {
+					settings::Logger::logDebug(
+						"[quic] [stream {}] End of stream received",
+						streamId ? *streamId : 0
+					);
+					break;
+				}
+
+				settings::Logger::logDebug(
+					"[quic] [stream {}] Received {:d} bytes in {:d} buffers",
+					streamId ? *streamId : 0,
+					event->RECEIVE.TotalBufferLength,
+					event->RECEIVE.BufferCount
+				);
+
+				std::vector<uint8_t> data;
+				data.reserve(event->RECEIVE.TotalBufferLength);
+
+				for (uint32_t i = 0; i < event->RECEIVE.BufferCount; ++i) {
+					const auto &b = event->RECEIVE.Buffers[i];
+					data.insert(data.end(), b.Buffer, b.Buffer + b.Length);
+				}
+
+				auto msg = std::make_shared<ExternalProtocol::ExternalServer>();
+				if (!msg->ParseFromArray(data.data(), static_cast<int>(data.size()))) {
+					settings::Logger::logError("[quic] Failed to parse ExternalServer message");
+				} else {
+					self->onMessageDecoded(std::move(msg));
+				}
+
+				break;
+			}
+
+			/// Raised when the peer has finished sending on this stream
+			/// (peer's FIN has been fully received and processed).
+			case QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN: {
+				settings::Logger::logDebug("[quic] [stream {}] Peer stream send shutdown", streamId ? *streamId : 0);
+				break;
+			}
+
+			/// Raised when the local send direction is fully shut down
+			/// and the peer has acknowledged the FIN.
+			case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE: {
+				settings::Logger::logDebug("[quic] [stream {}] Stream send shutdown complete",
+				                           streamId ? *streamId : 0);
+				break;
+			}
+
+			/// Raised after StreamStart completes successfully
+			/// and the stream becomes active with a valid stream ID.
+			case QUIC_STREAM_EVENT_START_COMPLETE: {
+				settings::Logger::logDebug("[quic] [stream {}] Stream start completed", streamId ? *streamId : 0);
+				break;
+			}
+
+			/// Raised when a single StreamSend operation completes
+			/// (data was accepted, acknowledged, or the send was canceled).
+			case QUIC_STREAM_EVENT_SEND_COMPLETE: {
+				/**
+				 * This event is raised when MsQuic has finished processing
+				 * a single StreamSend request.
+				 *
+				 * Meaning:
+				 *  - MsQuic no longer needs the application-provided buffer:
+				 *      - the data has been acknowledged (ACKed) by the peer
+				 *        at the QUIC transport level and will not be retransmitted
+				 *      - OR the send was canceled (Canceled == TRUE), e.g. due to
+				 *        stream or connection shutdown
+				 *
+				 * Reliability semantics:
+				 *  - the ACK is strictly a QUIC transport-level acknowledgment
+				 *  - it does NOT mean the peer application has read or processed
+				 *    the data
+				 *
+				 * Practical consequence:
+				 *  - this is the only correct place to safely free the memory
+				 *    passed to StreamSend (via ClientContext)
+				 */
+				if (event->SEND_COMPLETE.Canceled) {
+					settings::Logger::logDebug("[quic] [stream {}] Stream send canceled",
+					                           streamId ? *streamId : 0);
+				} else {
+					settings::Logger::logDebug("[quic] [stream {}] Stream send completed",
+					                           streamId ? *streamId : 0);
+				}
+
+				std::unique_ptr<SendBuffer> sendBuf{
+					static_cast<SendBuffer *>(event->SEND_COMPLETE.ClientContext)
+				};
+
+				break;
+			}
+
+			/// Raised when both send and receive directions are closed
+			/// and the stream lifecycle is fully complete.
+			case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE: {
+				settings::Logger::logDebug("[quic] [stream {}] Stream shutdown complete", streamId ? *streamId : 0);
+				self->quic_->StreamClose(stream);
+				break;
+			}
+
+			default: {
+				settings::Logger::logDebug("[quic] [stream {}] Unhandled stream event 0x{:x}", streamId ? *streamId : 0,
+				                           static_cast<unsigned>(event->Type));
+				break;
+			}
+		}
+
+		return QUIC_STATUS_SUCCESS;
+	}
+
+	void QuicCommunication::senderLoop() {
+		settings::Logger::logDebug("[quic] Sender thread loop started");
+
+		while (connectionState_.load() == ConnectionState::CONNECTED) {
+			std::unique_ptr<ExternalProtocol::ExternalClient> msg;
+
+			std::unique_lock lock(outboundMutex_);
+
+			settings::Logger::logDebug("[quic] Sender thread loop waiting for outbound queue");
+			outboundCv_.wait(lock, [this] {
+				return !outboundQueue_.empty() ||
+				       connectionState_.load() != ConnectionState::CONNECTED;
+			});
+
+			if (connectionState_.load() != ConnectionState::CONNECTED) {
+				break;
+			}
+
+			settings::Logger::logDebug("[quic] Sender thread loop sending outbound queue");
+			msg = std::move(outboundQueue_.front());
+			outboundQueue_.pop();
+			lock.unlock();
+
+			sendViaQuicStream(*msg);
+		}
+	}
+
+	std::optional<uint64_t> QuicCommunication::getStreamId(HQUIC stream) {
+		uint64_t streamId = 0;
+		uint32_t streamIdLen = sizeof(streamId);
+
+		if (QUIC_FAILED(quic_->GetParam(
+			stream,
+			QUIC_PARAM_STREAM_ID,
+			&streamIdLen,
+			&streamId))) {
+			return std::nullopt;
+		}
+
+		return streamId;
+	}
+
+	std::string QuicCommunication::getProtocolSettingsString(
+		const structures::ExternalConnectionSettings &settings,
+		std::string_view key
+	) {
+		const auto &raw = settings.protocolSettings.at(std::string(key));
+
+		if (nlohmann::json::accept(raw)) {
+			auto j = nlohmann::json::parse(raw);
+			if (j.is_string()) {
+				return j.get<std::string>();
+			}
+		}
+		return raw;
+	}
+}

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -38,6 +38,8 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::initializeConnection() {
+		cancelReceive_.store(false, std::memory_order_release);
+
 		settings::Logger::logDebug("[quic] Connecting to server when {}",
 		                           common_utils::EnumUtils::connectionStateToString(connectionState_));
 
@@ -98,6 +100,7 @@ namespace bringauto::external_client::connection::communication {
 			[this] {
 				auto state = connectionState_.load();
 				return !inboundQueue_.empty() ||
+				       cancelReceive_.load(std::memory_order_acquire) ||
 				       (state != ConnectionState::CONNECTING &&
 				        state != ConnectionState::CLOSING &&
 				        state != ConnectionState::CONNECTED);
@@ -194,6 +197,11 @@ namespace bringauto::external_client::connection::communication {
 		quic_->ConnectionShutdown(connection_, QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0);
 
 		/// Asynchronously waiting for QUIC_CONNECTION_EVENT_SHUTDOWN_COMPLETE event, then continue in connectionCallback
+	}
+
+	void QuicCommunication::cancelReceive() {
+		cancelReceive_.store(true, std::memory_order_release);
+		inboundCv_.notify_all();
 	}
 
 	void QuicCommunication::closeConfiguration() {
@@ -334,7 +342,6 @@ namespace bringauto::external_client::connection::communication {
 				settings::Logger::logInfo("[quic] Connection shutdown complete");
 
 				self->connectionState_ = ConnectionState::NOT_CONNECTED;
-				self->inboundCv_.notify_all();
 				self->outboundCv_.notify_all();
 
 				if (self->senderThread_.joinable()) {

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -334,6 +334,7 @@ namespace bringauto::external_client::connection::communication {
 				settings::Logger::logInfo("[quic] Connection shutdown complete");
 
 				self->connectionState_ = ConnectionState::NOT_CONNECTED;
+				self->inboundCv_.notify_all();
 				self->outboundCv_.notify_all();
 
 				if (self->senderThread_.joinable()) {

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -38,7 +38,7 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::initializeConnection() {
-		cancelReceive_.store(false, std::memory_order_release);
+		cancelReceive_.store(false);
 
 		settings::Logger::logDebug("[quic] Connecting to server when {}",
 		                           common_utils::EnumUtils::connectionStateToString(connectionState_));
@@ -100,7 +100,7 @@ namespace bringauto::external_client::connection::communication {
 			[this] {
 				auto state = connectionState_.load();
 				return !inboundQueue_.empty() ||
-				       cancelReceive_.load(std::memory_order_acquire) ||
+				       cancelReceive_.load() ||
 				       (state != ConnectionState::CONNECTING &&
 				        state != ConnectionState::CLOSING &&
 				        state != ConnectionState::CONNECTED);
@@ -200,7 +200,7 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::cancelReceive() {
-		cancelReceive_.store(true, std::memory_order_release);
+		cancelReceive_.store(true);
 		inboundCv_.notify_all();
 	}
 

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -211,6 +211,9 @@ Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::size_t size) {
 }
 
 Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::span<const uint8_t> data) {
+	if (data.empty()) {
+		return constructBuffer();
+	}
 	auto buff = constructBuffer(data.size());
 	std::memcpy(buff.getStructBuffer().data, data.data(), data.size());
 	return buff;

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -1,259 +1,211 @@
+#include <cstring>
+
+#include <bringauto/fleet_protocol/async_function_execution_definitions/AsyncModuleFunctionDefinitions.hpp>
+
 #include <bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp>
-#include <bringauto/settings/LoggerId.hpp>
+#include <bringauto/settings/Constants.hpp>
+#include <bringauto/modules/ModuleBinaryException.hpp>
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
 
+#include <chrono>
+#include <memory>
 #include <csignal>
-#include <thread>
 
 
 
 namespace bringauto::modules {
 
-ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, const int moduleNumber) :
+namespace fp_async = fleet_protocol::async_function_execution_definitions;
+
+using fp_async::ConvertibleBuffer;
+using fp_async::ConvertibleBufferReturn;
+
+static fp_async::ModuleFunctionExecutor aeronClient {
+	async_function_execution::Config {
+		.isProducer = true,
+		.defaultTimeout = std::chrono::seconds(1)
+	},
+	fp_async::moduleFunctionList
+};
+
+ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath) :
 		moduleBinaryPath_ { moduleBinaryPath } {
-	aeronClient.connect(moduleNumber);
-	deallocate_ = [this](struct buffer *buffer) {
-		this->deallocate(buffer);
-	};
+	aeronClient.connect();
 }
 
 ModuleManagerLibraryHandlerAsync::~ModuleManagerLibraryHandlerAsync() {
-	if (moduleBinaryProcess_.valid()) {
-		::kill(moduleBinaryProcess_.id(), SIGTERM);
-		try
-		{
+	try {
+		if (moduleBinaryProcess_.valid()) {
+			::kill(moduleBinaryProcess_.id(), SIGTERM);
 			moduleBinaryProcess_.wait();
 		}
-		catch (const std::exception& e)
-		{
-			settings::Logger::logError("Failed to wait for module binary process: {}", e.what());
-		}
-	}
+	} catch (...) { /* destructor must not throw */ }
 }
 
 void ModuleManagerLibraryHandlerAsync::loadLibrary(const std::filesystem::path &path) {
-	if(moduleBinaryProcess_.valid()) {
-		::kill(moduleBinaryProcess_.id(), SIGTERM);
-		try {
-			moduleBinaryProcess_.wait();
-		} catch(const std::system_error &e) {
-			settings::Logger::logError("Failed to wait for previous module binary process: {}", e.what());
-		}
-	}
-	// boost::process::child constructor throws boost::process::process_error on spawn failure.
 	moduleBinaryProcess_ = boost::process::child { moduleBinaryPath_.string(), "-m", path.string() };
+	if (!moduleBinaryProcess_.valid()) {
+		throw ModuleBinaryException { "Failed to start module binary " + moduleBinaryPath_.string() };
+	}
 	const auto deadline = std::chrono::steady_clock::now() + settings::AeronClientConstants::aeron_client_startup_timeout;
-	while(std::chrono::steady_clock::now() < deadline) {
-		if(aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::getModuleNumberAsync).has_value()) {
-			return;
+	while(!aeronClient.callFunc(fp_async::getModuleNumberAsync).has_value()) {
+		if(!moduleBinaryProcess_.running()) {
+			throw ModuleBinaryException { "Module binary terminated before becoming ready: " + moduleBinaryPath_.string() };
+		}
+		if(std::chrono::steady_clock::now() >= deadline) {
+			throw ModuleBinaryException { "Module binary did not respond within startup timeout: " + moduleBinaryPath_.string() };
 		}
 		std::this_thread::sleep_for(settings::AeronClientConstants::module_binary_poll_interval);
 	}
-	throw std::runtime_error { "Module binary " + moduleBinaryPath_.string() + " did not become ready within startup timeout" };
 }
 
-int ModuleManagerLibraryHandlerAsync::getModuleNumber() {
-	std::lock_guard lock { getModuleNumberMutex_ };
-	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::getModuleNumberAsync).value_or(NOT_OK);
+int ModuleManagerLibraryHandlerAsync::getModuleNumber() const {
+	return aeronClient.callFunc(fp_async::getModuleNumberAsync).value();
 }
 
 int ModuleManagerLibraryHandlerAsync::isDeviceTypeSupported(unsigned int device_type) {
-	std::lock_guard lock { isDeviceTypeSupportedMutex_ };
-	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::isDeviceTypeSupportedAsync,
-								device_type).value_or(NOT_OK);
+	std::lock_guard lock { tmpMutex_ };
+	return aeronClient.callFunc(fp_async::isDeviceTypeSupportedAsync, device_type).value();
 }
 
 int ModuleManagerLibraryHandlerAsync::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
-													 	  unsigned int device_type) {
-	std::lock_guard lock { sendStatusConditionMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_status_raw_buffer;
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
+													 	  unsigned int device_type) const {
+	ConvertibleBuffer current_status_raw_buffer;
+	ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 
-	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::sendStatusConditionAsync,
-								current_status_raw_buffer,
-								new_status_raw_buffer,
-								device_type).value_or(NOT_OK);
+	return aeronClient.callFunc(fp_async::sendStatusConditionAsync, current_status_raw_buffer, new_status_raw_buffer, device_type).value();
 }
 
 int ModuleManagerLibraryHandlerAsync::generateCommand(Buffer &generated_command,
 													  const Buffer &new_status,
 													  const Buffer &current_status,
 													  const Buffer &current_command, unsigned int device_type) {
-	std::lock_guard lock { generateCommandMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_status_raw_buffer;
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_command_raw_buffer;
+	ConvertibleBuffer new_status_raw_buffer;
+	ConvertibleBuffer current_status_raw_buffer;
+	ConvertibleBuffer current_command_raw_buffer;
 
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (current_command.isAllocated()) {
-		current_command_raw_buffer = current_command.getStructBuffer();
+		current_command_raw_buffer = ConvertibleBuffer{current_command.getStructBuffer()};
 	}
 
-	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::generateCommandAsync,
+	auto ret = aeronClient.callFunc(fp_async::generateCommandAsync,
 									new_status_raw_buffer,
 									current_status_raw_buffer,
 									current_command_raw_buffer,
-									device_type);
+									device_type).value();
 
-	if (!ret.has_value()) {
-		return NOT_OK;
-	}
-
-	if (ret.value().returnCode == OK) {
-		generated_command = constructBufferByTakeOwnership(ret.value().buffer);
+	if (ret.returnCode == OK) {
+		generated_command = constructBuffer(std::span<const uint8_t>{static_cast<const uint8_t*>(ret.buffer.data), ret.buffer.size_in_bytes});
 	} else {
 		generated_command = constructBuffer();
 	}
-	return ret.value().returnCode;
+	return ret.returnCode;
 }
 
 int ModuleManagerLibraryHandlerAsync::aggregateStatus(Buffer &aggregated_status,
 													  const Buffer &current_status,
 													  const Buffer &new_status, unsigned int device_type) {
-	std::lock_guard lock { aggregateStatusMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_status_raw_buffer;
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
+	ConvertibleBuffer current_status_raw_buffer;
+	ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
-		current_status_raw_buffer = current_status.getStructBuffer();
+		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};
 	}
 	if (new_status.isAllocated()) {
-		new_status_raw_buffer = new_status.getStructBuffer();
+		new_status_raw_buffer = ConvertibleBuffer{new_status.getStructBuffer()};
 	}
 
-	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::aggregateStatusAsync,
-									current_status_raw_buffer,
-									new_status_raw_buffer,
-									device_type);
-	if (!ret.has_value()) {
-		return NOT_OK;
-	}
-	if (ret.value().returnCode == OK) {
-		aggregated_status = constructBufferByTakeOwnership(ret.value().buffer);
+	auto ret = aeronClient.callFunc(fp_async::aggregateStatusAsync, current_status_raw_buffer, new_status_raw_buffer, device_type).value();
+	if (ret.returnCode == OK) {
+		aggregated_status = constructBuffer(std::span<const uint8_t>{static_cast<const uint8_t*>(ret.buffer.data), ret.buffer.size_in_bytes});
 	} else {
-		// Needed to properly free the allocated buffer memory
-		if (ret.value().buffer.data != nullptr) {
-			auto invalid_buffer = constructBufferByTakeOwnership(ret.value().buffer);
-		}
 		aggregated_status = current_status;
 	}
-	return ret.value().returnCode;
+	return ret.returnCode;
 }
 
 int ModuleManagerLibraryHandlerAsync::aggregateError(Buffer &error_message,
 													 const Buffer &current_error_message,
 													 const Buffer &status, unsigned int device_type) {
-	std::lock_guard lock { aggregateErrorMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_error_raw_buffer;
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer status_raw_buffer;
+	ConvertibleBuffer current_error_raw_buffer;
+	ConvertibleBuffer status_raw_buffer;
 
 	if (current_error_message.isAllocated()) {
-		current_error_raw_buffer = current_error_message.getStructBuffer();
+		current_error_raw_buffer = ConvertibleBuffer{current_error_message.getStructBuffer()};
 	}
 	if (status.isAllocated()) {
-		status_raw_buffer = status.getStructBuffer();
+		status_raw_buffer = ConvertibleBuffer{status.getStructBuffer()};
 	}
 
-	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::aggregateErrorAsync,
-									current_error_raw_buffer,
-									status_raw_buffer,
-									device_type);
-	if (!ret.has_value()) {
-		return NOT_OK;
-	}
-	if (ret.value().returnCode == OK) {
-		error_message = constructBufferByTakeOwnership(ret.value().buffer);
+	auto ret = aeronClient.callFunc(fp_async::aggregateErrorAsync, current_error_raw_buffer, status_raw_buffer, device_type).value();
+	if (ret.returnCode == OK) {
+		error_message = constructBuffer(std::span<const uint8_t>{static_cast<const uint8_t*>(ret.buffer.data), ret.buffer.size_in_bytes});
 	} else {
 		error_message = constructBuffer();
 	}
-	return ret.value().returnCode;
+	return ret.returnCode;
 }
 
 int ModuleManagerLibraryHandlerAsync::generateFirstCommand(Buffer &default_command, unsigned int device_type) {
-	std::lock_guard lock { generateFirstCommandMutex_ };
-	auto ret = aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::generateFirstCommandAsync, device_type);
-	if (!ret.has_value()) {
-		return NOT_OK;
-	}
-	if (ret.value().returnCode == OK) {
-		default_command = constructBufferByTakeOwnership(ret.value().buffer);
+	auto ret = aeronClient.callFunc(fp_async::generateFirstCommandAsync, device_type).value();
+	if (ret.returnCode == OK) {
+		default_command = constructBuffer(std::span<const uint8_t>{static_cast<const uint8_t*>(ret.buffer.data), ret.buffer.size_in_bytes});
 	} else {
 		default_command = constructBuffer();
 	}
-	return ret.value().returnCode;
+	return ret.returnCode;
 }
 
-int ModuleManagerLibraryHandlerAsync::statusDataValid(const Buffer &status, unsigned int device_type) {
-	std::lock_guard lock { statusDataValidMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer status_raw_buffer;
+int ModuleManagerLibraryHandlerAsync::statusDataValid(const Buffer &status, unsigned int device_type) const {
+	ConvertibleBuffer status_raw_buffer;
 	if (status.isAllocated()) {
-		status_raw_buffer = status.getStructBuffer();
+		status_raw_buffer = ConvertibleBuffer{status.getStructBuffer()};
 	}
 
-	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::statusDataValidAsync,
-								status_raw_buffer,
-								device_type).value_or(NOT_OK);
+	return aeronClient.callFunc(fp_async::statusDataValidAsync, status_raw_buffer, device_type).value();
 }
 
-int ModuleManagerLibraryHandlerAsync::commandDataValid(const Buffer &command, unsigned int device_type) {
-	std::lock_guard lock { commandDataValidMutex_ };
-	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer command_raw_buffer;
+int ModuleManagerLibraryHandlerAsync::commandDataValid(const Buffer &command, unsigned int device_type) const {
+	ConvertibleBuffer command_raw_buffer;
 	if (command.isAllocated()) {
-		command_raw_buffer = command.getStructBuffer();
+		command_raw_buffer = ConvertibleBuffer{command.getStructBuffer()};
 	}
 
-	return aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::commandDataValidAsync,
-								command_raw_buffer,
-								device_type).value_or(NOT_OK);
-}
-
-int ModuleManagerLibraryHandlerAsync::allocate(struct buffer *buffer_pointer, size_t size_in_bytes) const {
-	try{
-		buffer_pointer->data = new char[size_in_bytes]();
-	} catch(std::bad_alloc&){
-		return NOT_OK;
-	}
-	buffer_pointer->size_in_bytes = size_in_bytes;
-	return OK;
-}
-
-void ModuleManagerLibraryHandlerAsync::deallocate(struct buffer *buffer) const {
-	delete[] static_cast<char *>(buffer->data);
-	buffer->data = nullptr;
-	buffer->size_in_bytes = 0;
+	return aeronClient.callFunc(fp_async::commandDataValidAsync, command_raw_buffer, device_type).value();
 }
 
 Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::size_t size) {
-	if (size == 0) {
+	if(size == 0) {
 		return Buffer {};
 	}
-	struct ::buffer buff {};
-	buff.size_in_bytes = size;
-	if(allocate(&buff, size) != OK) {
-		throw std::bad_alloc {};
-	}
-	return { buff, deallocate_ };
+	auto data = std::make_unique<char[]>(size);
+	struct ::buffer buff { .data = data.release(), .size_in_bytes = size };
+	return { buff, [](struct ::buffer *b) {
+		std::unique_ptr<char[]> { static_cast<char *>(b->data) };
+		b->data = nullptr;
+		b->size_in_bytes = 0;
+	}};
 }
 
-Buffer ModuleManagerLibraryHandlerAsync::constructBufferByTakeOwnership(struct ::buffer &buffer) {
-	if (buffer.data == nullptr) {
-		throw Buffer::BufferNotAllocated { "Buffer not allocated - cannot take ownership" };
-	}
-	return { buffer, deallocate_ };
+Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::span<const uint8_t> data) {
+	auto buff = constructBuffer(data.size());
+	std::memcpy(buff.getStructBuffer().data, data.data(), data.size());
+	return buff;
 }
 
 }

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -29,31 +29,38 @@ static fp_async::ModuleFunctionExecutor aeronClient {
 	fp_async::moduleFunctionList
 };
 
-ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath) :
+ModuleManagerLibraryHandlerAsync::ModuleManagerLibraryHandlerAsync(const std::filesystem::path &moduleBinaryPath, int moduleNumber) :
 		moduleBinaryPath_ { moduleBinaryPath } {
-	aeronClient.connect();
+	aeronClient.connect(moduleNumber);
 }
 
 ModuleManagerLibraryHandlerAsync::~ModuleManagerLibraryHandlerAsync() {
+	if (!moduleBinaryProcess_.valid()) {
+		return;
+	}
+	::kill(moduleBinaryProcess_.id(), SIGTERM);
 	try {
-		if (moduleBinaryProcess_.valid()) {
-			::kill(moduleBinaryProcess_.id(), SIGTERM);
-			moduleBinaryProcess_.wait();
-		}
-	} catch (...) { /* destructor must not throw */ }
+		moduleBinaryProcess_.wait();
+	} catch (const boost::process::process_error&) {
+		// wait() failed — process already reaped or unreachable. Nothing to do.
+	}
 }
 
 void ModuleManagerLibraryHandlerAsync::loadLibrary(const std::filesystem::path &path) {
-	moduleBinaryProcess_ = boost::process::child { moduleBinaryPath_.string(), "-m", path.string() };
+	try {
+		moduleBinaryProcess_ = boost::process::child { moduleBinaryPath_.string(), "-m", path.string() };
+	} catch (const boost::process::process_error& e) {
+		throw ModuleBinaryException { "Failed to start module binary " + moduleBinaryPath_.string() + ": " + e.what() };
+	}
 	if (!moduleBinaryProcess_.valid()) {
 		throw ModuleBinaryException { "Failed to start module binary " + moduleBinaryPath_.string() };
 	}
 	const auto deadline = std::chrono::steady_clock::now() + settings::AeronClientConstants::aeron_client_startup_timeout;
-	while(!aeronClient.callFunc(fp_async::getModuleNumberAsync).has_value()) {
-		if(!moduleBinaryProcess_.running()) {
+	while (!aeronClient.callFunc(fleet_protocol::async_function_execution_definitions::getModuleNumberAsync).has_value()) {
+		if (!moduleBinaryProcess_.running()) {
 			throw ModuleBinaryException { "Module binary terminated before becoming ready: " + moduleBinaryPath_.string() };
 		}
-		if(std::chrono::steady_clock::now() >= deadline) {
+		if (std::chrono::steady_clock::now() >= deadline) {
 			throw ModuleBinaryException { "Module binary did not respond within startup timeout: " + moduleBinaryPath_.string() };
 		}
 		std::this_thread::sleep_for(settings::AeronClientConstants::module_binary_poll_interval);
@@ -72,8 +79,9 @@ int ModuleManagerLibraryHandlerAsync::isDeviceTypeSupported(unsigned int device_
 int ModuleManagerLibraryHandlerAsync::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
 													 	  unsigned int device_type) const {
-	ConvertibleBuffer current_status_raw_buffer;
-	ConvertibleBuffer new_status_raw_buffer;
+	std::lock_guard lock { tmpMutex_ };
+	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer current_status_raw_buffer;
+	fleet_protocol::async_function_execution_definitions::ConvertibleBuffer new_status_raw_buffer;
 
 	if (current_status.isAllocated()) {
 		current_status_raw_buffer = ConvertibleBuffer{current_status.getStructBuffer()};

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -76,7 +76,8 @@ int ModuleManagerLibraryHandlerLocal::isDeviceTypeSupported(unsigned int device_
 
 int ModuleManagerLibraryHandlerLocal::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
-														  unsigned int device_type) const {
+														  unsigned int device_type)
+const {
 	struct ::buffer current_status_raw_buffer {};
 	struct ::buffer new_status_raw_buffer {};
 

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -1,4 +1,5 @@
 #include <bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp>
+#include <bringauto/modules/library_loader.hpp>
 #include <bringauto/settings/LoggerId.hpp>
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
@@ -28,7 +29,7 @@ ModuleManagerLibraryHandlerLocal::~ModuleManagerLibraryHandlerLocal() {
 }
 
 void ModuleManagerLibraryHandlerLocal::loadLibrary(const std::filesystem::path &path) {
-	module_ = dlmopen(LM_ID_NEWLM, path.c_str(), RTLD_LAZY);
+	module_ = library_loader::load(path);
 	if(module_ == nullptr) {
 		throw std::runtime_error {"Unable to load library " + path.string() + ": " + dlerror()};
 	}
@@ -65,7 +66,7 @@ void *ModuleManagerLibraryHandlerLocal::checkFunction(const char *functionName) 
 	return function;
 }
 
-int ModuleManagerLibraryHandlerLocal::getModuleNumber() {
+int ModuleManagerLibraryHandlerLocal::getModuleNumber() const {
 	return getModuleNumber_();
 }
 
@@ -75,7 +76,7 @@ int ModuleManagerLibraryHandlerLocal::isDeviceTypeSupported(unsigned int device_
 
 int ModuleManagerLibraryHandlerLocal::sendStatusCondition(const Buffer &current_status,
 														  const Buffer &new_status,
-														  unsigned int device_type) {
+														  unsigned int device_type) const {
 	struct ::buffer current_status_raw_buffer {};
 	struct ::buffer new_status_raw_buffer {};
 
@@ -176,7 +177,7 @@ int ModuleManagerLibraryHandlerLocal::generateFirstCommand(Buffer &default_comma
 	return ret;
 }
 
-int ModuleManagerLibraryHandlerLocal::statusDataValid(const Buffer &status, unsigned int device_type) {
+int ModuleManagerLibraryHandlerLocal::statusDataValid(const Buffer &status, unsigned int device_type) const {
 	struct ::buffer raw_buffer {};
 	if (status.isAllocated()) {
 		raw_buffer = status.getStructBuffer();
@@ -184,7 +185,7 @@ int ModuleManagerLibraryHandlerLocal::statusDataValid(const Buffer &status, unsi
 	return statusDataValid_(raw_buffer, device_type);
 }
 
-int ModuleManagerLibraryHandlerLocal::commandDataValid(const Buffer &command, unsigned int device_type) {
+int ModuleManagerLibraryHandlerLocal::commandDataValid(const Buffer &command, unsigned int device_type) const {
 	struct ::buffer raw_buffer {};
 	if (command.isAllocated()) {
 		raw_buffer = command.getStructBuffer();

--- a/source/bringauto/modules/library_loader_production.cpp
+++ b/source/bringauto/modules/library_loader_production.cpp
@@ -1,0 +1,11 @@
+#include <bringauto/modules/library_loader.hpp>
+
+
+
+namespace bringauto::modules::library_loader {
+
+void* load(const std::filesystem::path& path) {
+	return ::dlmopen(LM_ID_NEWLM, path.c_str(), RTLD_LAZY);
+}
+
+}

--- a/source/bringauto/settings/QuicSettingsParser.cpp
+++ b/source/bringauto/settings/QuicSettingsParser.cpp
@@ -29,6 +29,12 @@ namespace bringauto::settings {
 			quic.IsSet.DisconnectTimeoutMs = TRUE;
 		}
 
+		if (auto value = getOptionalUint(settings, "PeerUnidiStreamCount"); value.has_value()) {
+			settings::Logger::logDebug("[quic] [settings] PeerUnidiStreamCount settings loaded");
+			quic.PeerUnidiStreamCount = *value;
+			quic.IsSet.PeerUnidiStreamCount = TRUE;
+		}
+
 		return quic;
 	}
 

--- a/source/bringauto/settings/QuicSettingsParser.cpp
+++ b/source/bringauto/settings/QuicSettingsParser.cpp
@@ -1,0 +1,64 @@
+#include <bringauto/settings/QuicSettingsParser.hpp>
+#include <bringauto/structures/ExternalConnectionSettings.hpp>
+#include <bringauto/settings/LoggerId.hpp>
+
+#include <nlohmann/json.hpp>
+
+
+namespace bringauto::settings {
+	QUIC_SETTINGS QuicSettingsParser::parse(
+		const structures::ExternalConnectionSettings &settings
+	) {
+		QUIC_SETTINGS quic{};
+
+		if (auto value = getOptionalUint(settings, "IdleTimeoutMs"); value.has_value()) {
+			settings::Logger::logDebug("[quic] [settings] IdleTimeoutMs settings loaded");
+			quic.IdleTimeoutMs = *value;
+			quic.IsSet.IdleTimeoutMs = TRUE;
+		}
+
+		if (auto value = getOptionalUint(settings, "HandshakeIdleTimeoutMs"); value.has_value()) {
+			settings::Logger::logDebug("[quic] [settings] HandshakeIdleTimeoutMs settings loaded");
+			quic.HandshakeIdleTimeoutMs = *value;
+			quic.IsSet.HandshakeIdleTimeoutMs = TRUE;
+		}
+
+		if (auto value = getOptionalUint(settings, "DisconnectTimeoutMs"); value.has_value()) {
+			settings::Logger::logDebug("[quic] [settings] DisconnectTimeoutMs settings loaded");
+			quic.DisconnectTimeoutMs = *value;
+			quic.IsSet.DisconnectTimeoutMs = TRUE;
+		}
+
+		return quic;
+	}
+
+	std::optional<uint64_t> QuicSettingsParser::getOptionalUint(
+		const structures::ExternalConnectionSettings &settings,
+		std::string_view key
+	) {
+		const auto it = settings.protocolSettings.find(std::string(key));
+		if (it == settings.protocolSettings.end()) {
+			return std::nullopt;
+		}
+
+		const auto &raw = it->second;
+
+		if (!nlohmann::json::accept(raw)) {
+			settings::Logger::logWarning(
+				"[quic] QUIC setting '{}' is not valid JSON", key
+			);
+			return std::nullopt;
+		}
+
+		auto j = nlohmann::json::parse(raw);
+
+		if (!j.is_number_unsigned()) {
+			settings::Logger::logWarning(
+				"[quic] QUIC setting '{}' must be an unsigned integer", key
+			);
+			return std::nullopt;
+		}
+
+		return j.get<uint64_t>();
+	}
+}

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -118,7 +118,6 @@ bool SettingsParser::areSettingsCorrect() const {
 			}
 		}
 	}
-
 	return isCorrect;
 }
 
@@ -174,7 +173,6 @@ void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
 	if(file.contains(std::string(Constants::MODULE_BINARY_PATH))) {
 		settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 	}
-	settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 }
 
 void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) const {
@@ -210,6 +208,10 @@ void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) 
 		
 		if(!settingsName.empty() && endpoint.find(settingsName) != endpoint.end()) {
 			for(auto &[key, val]: endpoint[settingsName].items()) {
+				if (val.is_string()) {
+					externalConnectionSettings.protocolSettings[key] = val.get<std::string>();
+					continue;
+				}
 				externalConnectionSettings.protocolSettings[key] = to_string(val);
 			}
 		}
@@ -262,7 +264,11 @@ std::string SettingsParser::serializeToJson() const {
 				break;
 		}
 		for(const auto &[key, val]: endpoint.protocolSettings) {
-			endpointAsJson[settingsName][key] = nlohmann::json::parse(val);
+			if (nlohmann::json::accept(val)) {
+				endpointAsJson[settingsName][key] = nlohmann::json::parse(val);
+				continue;
+			}
+			endpointAsJson[settingsName][key] = val;
 		}
 		endpoints.push_back(endpointAsJson);
 	}

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -164,7 +164,7 @@ void SettingsParser::fillInternalServerSettings(const nlohmann::json &file) cons
 void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
 	for(auto &[key, val]: file[std::string(Constants::MODULE_PATHS)].items()) {
 		try {
-			val.get_to(settings_->modulePaths[stoi(key)]);
+			settings_->modulePaths[stoi(key)] = val.get<std::string>();
 		} catch(const std::invalid_argument &) {
 			throw std::invalid_argument { "Module path key '" + key + "' is not a valid integer module number" };
 		} catch(const std::out_of_range &) {
@@ -172,8 +172,9 @@ void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
 		}
 	}
 	if(file.contains(std::string(Constants::MODULE_BINARY_PATH))) {
-		file.at(std::string(Constants::MODULE_BINARY_PATH)).get_to(settings_->moduleBinaryPath);
+		settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 	}
+	settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 }
 
 void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) const {
@@ -191,6 +192,9 @@ void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) 
 		switch(externalConnectionSettings.protocolType) {
 			case structures::ProtocolType::MQTT:
 				settingsName = std::string(Constants::MQTT_SETTINGS);
+				break;
+			case structures::ProtocolType::QUIC:
+				settingsName = std::string(Constants::QUIC_SETTINGS);
 				break;
 			case structures::ProtocolType::DUMMY:
 				break;
@@ -230,7 +234,7 @@ std::string SettingsParser::serializeToJson() const {
 
 	settingsAsJson[std::string(Constants::INTERNAL_SERVER_SETTINGS)][std::string(Constants::PORT)] = settings_->port;
 	for(const auto &[key, val]: settings_->modulePaths) {
-		settingsAsJson[std::string(Constants::MODULE_PATHS)][std::to_string(key)] = val;
+		settingsAsJson[std::string(Constants::MODULE_PATHS)][std::to_string(key)] = val.string();
 	}
 
 	settingsAsJson[std::string(Constants::EXTERNAL_CONNECTION)][std::string(Constants::COMPANY)] = settings_->company;
@@ -246,6 +250,9 @@ std::string SettingsParser::serializeToJson() const {
 		switch (endpoint.protocolType) {
 			case structures::ProtocolType::MQTT:
 				settingsName = std::string(Constants::MQTT_SETTINGS);
+				break;
+			case structures::ProtocolType::QUIC:
+				settingsName = std::string(Constants::QUIC_SETTINGS);
 				break;
 			case structures::ProtocolType::DUMMY:
 				// DUMMY has no protocol-specific settings; settingsName stays empty

--- a/source/bringauto/structures/ModuleLibrary.cpp
+++ b/source/bringauto/structures/ModuleLibrary.cpp
@@ -19,7 +19,7 @@ void ModuleLibrary::loadLibraries(const std::unordered_map<int, std::filesystem:
 		if (moduleBinaryPath.empty()) {
 			handler = std::make_shared<modules::ModuleManagerLibraryHandlerLocal>();
 		} else {
-			handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath);
+			handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath, key);
 		}
 		handler->loadLibrary(path);
 		if (handler->getModuleNumber() != key)

--- a/source/bringauto/structures/ModuleLibrary.cpp
+++ b/source/bringauto/structures/ModuleLibrary.cpp
@@ -13,33 +13,26 @@ ModuleLibrary::~ModuleLibrary() {
 				  [](auto &pair) { pair.second->destroy_status_aggregator(); });
 }
 
-void ModuleLibrary::loadLibraries(const std::unordered_map<int, std::filesystem::path> &libPaths) {
-	std::shared_ptr<modules::IModuleManagerLibraryHandler> handler;
-	for(auto const &[key, path]: libPaths) {
-		handler = std::make_shared<modules::ModuleManagerLibraryHandlerLocal>();
-		handler->loadLibrary(path);
-		if(handler->getModuleNumber() != key) {
-			settings::Logger::logError("Module number from shared library {} does not match the module number from config. Config: {}, binary: {}.", path.string(), key, handler->getModuleNumber());
-			throw std::runtime_error {"Module numbers from config are not corresponding to binaries. Unable to continue. Fix configuration file."};
-		}
-		auto [it, inserted] = moduleLibraryHandlers.try_emplace(key, handler);
-		if(!inserted) {
-			settings::Logger::logWarning("Module with number: {} is already registered, skipping duplicate", key);
-		}
-	}
-}
-
 void ModuleLibrary::loadLibraries(const std::unordered_map<int, std::filesystem::path> &libPaths, const std::filesystem::path &moduleBinaryPath) {
 	std::shared_ptr<modules::IModuleManagerLibraryHandler> handler;
 	for(auto const &[key, path]: libPaths) {
-		handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath, key);
-		handler->loadLibrary(path);
-		if(handler->getModuleNumber() != key) {
-			settings::Logger::logError("Module number from shared library {} does not match the module number from config. Config: {}, binary: {}.", path.string(), key, handler->getModuleNumber());
-			throw std::runtime_error {"Module numbers from config are not corresponding to binaries. Unable to continue. Fix configuration file."};
+		if (moduleBinaryPath.empty()) {
+			handler = std::make_shared<modules::ModuleManagerLibraryHandlerLocal>();
+		} else {
+			handler = std::make_shared<modules::ModuleManagerLibraryHandlerAsync>(moduleBinaryPath);
 		}
-		auto [it, inserted] = moduleLibraryHandlers.try_emplace(key, handler);
-		if(!inserted) {
+		handler->loadLibrary(path);
+		if (handler->getModuleNumber() != key)
+		{
+			settings::Logger::logError(
+				"Module number from shared library {} does not match the module number from config. Config: {},"
+				" binary: {}.", path.string(), key, handler->getModuleNumber());
+			throw std::runtime_error{ // NOSONAR - generic exception is sufficient, error is unrecoverable and always propagates to top level
+				"Module numbers from config are not corresponding to binaries. Unable to continue."
+				" Fix configuration file."
+			};
+		}
+		if(auto [it, inserted] = moduleLibraryHandlers.try_emplace(key, handler); !inserted) {
 			settings::Logger::logWarning("Module with number: {} is already registered, skipping duplicate", key);
 		}
 	}

--- a/test/include/ExternalConnectionTests.hpp
+++ b/test/include/ExternalConnectionTests.hpp
@@ -34,8 +34,7 @@ protected:
 			moduleLibrary_->loadLibraries(context_->settings->modulePaths);
 			moduleLibrary_->initStatusAggregators(context_);
 		} catch(std::exception &e) {
-			std::cerr << "[ERROR] Error occurred during module initialization: " << e.what() << std::endl;
-			return;
+			GTEST_SKIP() << "Module initialization failed: " << e.what();
 		}
 
 		fromExternalQueue_ = std::make_shared<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand >>();
@@ -51,11 +50,13 @@ protected:
 
 		communicationChannel_ = std::make_shared<testing_utils::CommunicationMock>(context_->settings->externalConnectionSettingsList[0]);
 		externalConnection_->init(communicationChannel_);
+		auto roleBuffer = create_buffer("role");
+		auto nameBuffer = create_buffer("name");
 		::device_identification device {
 			.module = MODULE,
 			.device_type = BUTTON_DEVICE_TYPE,
-			.device_role = create_buffer("role").getStructBuffer(),
-			.device_name = create_buffer("name").getStructBuffer(),
+			.device_role = roleBuffer.getStructBuffer(),
+			.device_name = nameBuffer.getStructBuffer(),
 			.priority = 0
 		};
 		connectedDevices_.emplace_back(bringauto::structures::DeviceIdentification(device));
@@ -64,7 +65,9 @@ protected:
 	};
 
 	void TearDown() override {
-		externalConnection_->deinitializeConnection(true);
+		if(externalConnection_) {
+			externalConnection_->deinitializeConnection(true);
+		}
 		context_.reset();
 		moduleLibrary_.reset();
 		fromExternalQueue_.reset();

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -24,6 +24,8 @@ public:
 
 	void cancelReceive() override { /* no-op: mock receiveMessage() is controlled via queued messages */ }
 
+	bool consumeServerDisconnectNotification() override { return false; }
+
 	std::string getSessionId() const;
 
 	void setFailOnInitConnection(bool failOnInitConnection);

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -22,6 +22,8 @@ public:
 
 	void closeConnection() override;
 
+	void cancelReceive() override { /* no-op: mock receiveMessage() is controlled via queued messages */ }
+
 	std::string getSessionId() const;
 
 	void setFailOnInitConnection(bool failOnInitConnection);

--- a/test/include/testing_utils/ConfigMock.hpp
+++ b/test/include/testing_utils/ConfigMock.hpp
@@ -50,15 +50,15 @@ public:
 				int port { 1883 };
 				
 				std::unordered_map<std::string, std::string> mqtt_settings {
-					{ "ssl", "\"false\"" },
-					{ "ca-file", "\"ca.pem\"" },
-					{ "client-cert", "\"client.pem\"" },
-					{ "client", "\"key.pem\"" }
+					{ "ssl", "false" },
+					{ "ca-file", "ca.pem" },
+					{ "client-cert", "client.pem" },
+					{ "client", "key.pem" }
 				};
 				std::string mqttSettingsToString() const {
 					std::string result = "";
 					for (auto [key, value] : mqtt_settings) {
-						result += std::format("\"{}\": {},\n", key, value);
+						result += std::format("\"{}\": \"{}\",\n", key, value);
 					}
 					if (!result.empty()) {
 						result.pop_back();

--- a/test/include/testing_utils/ConfigMock.hpp
+++ b/test/include/testing_utils/ConfigMock.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <format>
 #include <iostream>
 #include <unordered_map>

--- a/test/source/StatusAggregatorTests.cpp
+++ b/test/source/StatusAggregatorTests.cpp
@@ -100,7 +100,7 @@ TEST_F(StatusAggregatorTests, add_status_to_aggregator_without_aggregation){
 	libHandler->loadLibrary(PATH_TO_MODULE);
 	add_status_to_aggregator();
 	auto size = std::string(BUTTON_PRESSED).size();
-	auto status_buffer = libHandler->constructBuffer(size);
+	auto status_buffer = libHandler->constructBuffer(size + 1);
 	strcpy(static_cast<char *>(status_buffer.getStructBuffer().data), BUTTON_PRESSED);
 	auto deviceId = testing_utils::DeviceIdentificationHelper::createDeviceIdentification(MODULE, SUPPORTED_DEVICE_TYPE, DEVICE_ROLE, DEVICE_NAME, 10);
 	int ret = statusAggregator_->add_status_to_aggregator(status_buffer, deviceId);

--- a/test/source/library_loader_test.cpp
+++ b/test/source/library_loader_test.cpp
@@ -1,0 +1,11 @@
+#include <bringauto/modules/library_loader.hpp>
+
+
+
+namespace bringauto::modules::library_loader {
+
+void* load(const std::filesystem::path& path) {
+	return ::dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+}
+
+}


### PR DESCRIPTION
## Summary
- Replace `push` with `pushAndNotify` on all `reconnectQueue_` sites so the reconnect loop wakes up immediately instead of waiting for the next `waitForValueWithTimeout` timeout to expire

## Test plan
- Integration tests (`ts_260` in `BOTH` scenario) pass
- Unit tests pass