### PR TITLE
refactor: extract ConnectedDevices from InternalServer

### DIFF
--- a/include/bringauto/internal_server/ConnectedDevices.hpp
+++ b/include/bringauto/internal_server/ConnectedDevices.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <bringauto/structures/AtomicQueue.hpp>
+#include <bringauto/structures/Connection.hpp>
+#include <bringauto/structures/DeviceIdentification.hpp>
+#include <bringauto/structures/InternalClientMessage.hpp>
+
+#include <InternalProtocol.pb.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+
+
+namespace bringauto::internal_server {
+
+/**
+ * Thread-safe registry of active device connections, protected by an internal mutex.
+ * All compound operations (find + modify) are exposed as single atomic methods.
+ */
+class ConnectedDevices {
+public:
+	enum class RegisterResult { Connected, AlreadyConnected, HigherPriorityConnected };
+
+	/**
+	 * @brief Attempts to register a new connection for a device.
+	 * If no existing connection for deviceId: registers and enqueues a connect message.
+	 * If existing connection has same priority: returns AlreadyConnected (caller sends rejection).
+	 * If existing has higher priority: returns HigherPriorityConnected (caller sends rejection).
+	 * If existing has lower priority: closes old connection and replaces it with the new one.
+	 */
+	RegisterResult try_register(const std::shared_ptr<structures::Connection> &connection,
+								const InternalProtocol::InternalClient &connect,
+								const structures::DeviceIdentification &deviceId,
+								structures::AtomicQueue<structures::InternalClientMessage> &queue);
+
+	/**
+	 * @brief Closes and removes a connection from the registry.
+	 * Only removes if the connection matches by device id and priority.
+	 */
+	void remove(const std::shared_ptr<structures::Connection> &connection,
+				structures::AtomicQueue<structures::InternalClientMessage> &queue);
+
+	/**
+	 * @brief Finds and removes the connection for the given device id.
+	 */
+	void remove_by_id(const structures::DeviceIdentification &deviceId,
+					  structures::AtomicQueue<structures::InternalClientMessage> &queue);
+
+	/**
+	 * @brief Finds the connection matching deviceId and priority, sends message via send_fn,
+	 * then sets connection->ready and notifies the waiting thread.
+	 * Lock order: internal mutex_ then connection->connectionMutex.
+	 */
+	void deliver(const InternalProtocol::InternalServer &message,
+				 const structures::DeviceIdentification &deviceId,
+				 const std::function<bool(const std::shared_ptr<structures::Connection> &,
+										 const InternalProtocol::InternalServer &)> &send_fn);
+
+private:
+	std::mutex mutex_;
+	std::vector<std::shared_ptr<structures::Connection>> devices_;
+
+	std::shared_ptr<structures::Connection> find_locked(const structures::DeviceIdentification &deviceId);
+
+	void add_locked(const std::shared_ptr<structures::Connection> &connection,
+					const InternalProtocol::InternalClient &connect,
+					const structures::DeviceIdentification &deviceId,
+					structures::AtomicQueue<structures::InternalClientMessage> &queue);
+
+	void remove_locked(const std::shared_ptr<structures::Connection> &connection,
+					   structures::AtomicQueue<structures::InternalClientMessage> &queue);
+};
+
+} // namespace bringauto::internal_server

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -163,15 +163,6 @@ private:
 						  const structures::DeviceIdentification &deviceId);
 
 	/**
-	 * @brief Writes messages to Internal client.
-	 * @param connection connection message will be sent through
-	 * @param message message to be sent
-	 * @return true if writes are successful
-	 */
-	bool sendResponse(const std::shared_ptr<structures::Connection> &connection,
-					  const InternalProtocol::InternalServer &message);
-
-	/**
 	 * @brief Removes Connection from the map of active connections and clean up/closes its socket
 	 * @param connection connection to be removed
 	 */

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bringauto/internal_server/ConnectedDevices.hpp>
 #include <bringauto/structures/AtomicQueue.hpp>
 #include <bringauto/structures/Connection.hpp>
 #include <bringauto/structures/GlobalContext.hpp>
@@ -121,34 +122,6 @@ private:
 	void handleDisconnect(const structures::DeviceIdentification& deviceId);
 
 	/**
-	 * @brief Inserts connection into map of all active connections, sends message to module Handler.
-	 * @param connection connection to be inserted into map
-	 * @param connect message to be sent
-	 * @param deviceId unique device identification
-	 */
-	void connectNewDevice(const std::shared_ptr<structures::Connection> &connection,
-						  const InternalProtocol::InternalClient &connect,
-						  const structures::DeviceIdentification &deviceId);
-
-	/**
-	 * Ends all operations of previous connection using same device,
-	 * closes its socket, then replaces it in map with new connection.
-	 * Afterward sends new connection message to Module Handler.
-	 * @param newConnection new connection to replace the old one
-	 * @param connect message to be sent
-	 * @param deviceId unique device identification
-	 */
-	void changeConnection(const std::shared_ptr<structures::Connection> &newConnection,
-						  const InternalProtocol::InternalClient &connect,
-						  const structures::DeviceIdentification &deviceId);
-
-	/**
-	 * @brief Removes Connection from the map of active connections and clean up/closes its socket
-	 * @param connection connection to be removed
-	 */
-	void removeConnFromMap(const std::shared_ptr<structures::Connection> &connection);
-
-	/**
 	 * Periodically checks for new messages received from module handler through queue.
 	 * If message is received calls validatesResponse(...).
 	 * Runs until stop() is called.
@@ -162,13 +135,6 @@ private:
 	 */
 	void validateResponse(const InternalProtocol::InternalServer &message);
 
-	/**
-	 * @brief Searches for connection in connectedDevices_ vector with deviceId, which is "same" as given deviceId.
-	 * @param deviceId that will be searched for in the vector
-	 * @return connection in connectedDevices_ vector
-	 */
-	std::shared_ptr<structures::Connection> findConnection(const structures::DeviceIdentification &deviceId);
-
 	std::shared_ptr<structures::GlobalContext> context_ {};
 	boost::asio::ip::tcp::acceptor acceptor_;
 	/// Queue for messages from Module Handler to Internal Client
@@ -176,9 +142,7 @@ private:
 	/// Queue for messages from Internal Client to Module Handler
 	std::shared_ptr<structures::AtomicQueue<structures::ModuleHandlerMessage>> toInternalQueue_ {};
 
-	std::mutex serverMutex_ {};
-	/// Vector of all active connections of devices
-	std::vector<std::shared_ptr<structures::Connection>> connectedDevices_ {};
+	ConnectedDevices connectedDevices_ {};
 	/// Thread that listens to queue for messages from Module Handler
 	std::jthread listeningThread {};
 };

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -131,16 +131,6 @@ private:
 						  const structures::DeviceIdentification &deviceId);
 
 	/**
-	 * @brief Sends response to InternalClient, that device is already connected and with higher priority.
-	 * @param connection connection response will be sent through
-	 * @param connect message containing data for response message
-	 * @param deviceId unique device identification
-	 */
-	void respondWithHigherPriorityConnected(const std::shared_ptr<structures::Connection> &connection,
-											const InternalProtocol::InternalClient &connect,
-											const structures::DeviceIdentification &deviceId);
-
-	/**
 	 * @brief Sends response to InternalClient, that device is already connected and with same priority.
 	 * @param connection connection response will be sent through
 	 * @param connect message containing data for response message

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -131,16 +131,6 @@ private:
 						  const structures::DeviceIdentification &deviceId);
 
 	/**
-	 * @brief Sends response to InternalClient, that device is already connected and with same priority.
-	 * @param connection connection response will be sent through
-	 * @param connect message containing data for response message
-	 * @param deviceId unique device identification
-	 */
-	void respondWithAlreadyConnected(const std::shared_ptr<structures::Connection> &connection,
-									 const InternalProtocol::InternalClient &connect,
-									 const structures::DeviceIdentification &deviceId);
-
-	/**
 	 * Ends all operations of previous connection using same device,
 	 * closes its socket, then replaces it in map with new connection.
 	 * Afterward sends new connection message to Module Handler.

--- a/source/bringauto/internal_server/ConnectedDevices.cpp
+++ b/source/bringauto/internal_server/ConnectedDevices.cpp
@@ -1,0 +1,124 @@
+#include <bringauto/internal_server/ConnectedDevices.hpp>
+#include <bringauto/settings/LoggerId.hpp>
+
+#include <algorithm>
+
+
+
+namespace bringauto::internal_server {
+
+using log = settings::Logger;
+
+
+std::shared_ptr<structures::Connection>
+ConnectedDevices::find_locked(const structures::DeviceIdentification &deviceId) {
+	const auto it = std::find_if(devices_.begin(), devices_.end(),
+								 [&deviceId](const auto &toCompare) {
+									 return deviceId.isSame(toCompare->deviceId);
+								 });
+	if(it != devices_.end()) {
+		return *it;
+	}
+	return {};
+}
+
+void ConnectedDevices::add_locked(const std::shared_ptr<structures::Connection> &connection,
+								  const InternalProtocol::InternalClient &connect,
+								  const structures::DeviceIdentification &deviceId,
+								  structures::AtomicQueue<structures::InternalClientMessage> &queue) {
+	connection->deviceId = std::make_shared<structures::DeviceIdentification>(deviceId);
+	devices_.push_back(connection);
+	queue.pushAndNotify(structures::InternalClientMessage(false, connect));
+	log::logInfo(
+			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
+			"has been added into the vector of active connections",
+			connection->deviceId->getModule(),
+			connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
+			connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
+}
+
+void ConnectedDevices::remove_locked(const std::shared_ptr<structures::Connection> &connection,
+									 structures::AtomicQueue<structures::InternalClientMessage> &queue) {
+	boost::system::error_code error {};
+	connection->socket.shutdown(boost::asio::socket_base::shutdown_both, error);
+	connection->socket.close(error);
+	if(connection->deviceId == nullptr) {
+		return;
+	}
+	const auto it = std::find_if(devices_.begin(), devices_.end(),
+								 [&connection](const std::shared_ptr<structures::Connection> &toCompare) {
+									 return connection->deviceId->isSame(toCompare->deviceId);
+								 });
+	if(it != devices_.end() && (*it)->deviceId->getPriority() == connection->deviceId->getPriority()) {
+		devices_.erase(it);
+		log::logInfo(
+				"connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {})"
+				" has been closed and erased", connection->deviceId->getModule(),
+				connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
+				connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
+		queue.pushAndNotify(structures::InternalClientMessage(*connection->deviceId));
+	}
+}
+
+ConnectedDevices::RegisterResult
+ConnectedDevices::try_register(const std::shared_ptr<structures::Connection> &connection,
+							   const InternalProtocol::InternalClient &connect,
+							   const structures::DeviceIdentification &deviceId,
+							   structures::AtomicQueue<structures::InternalClientMessage> &queue) {
+	std::lock_guard lock(mutex_);
+	const auto existing = find_locked(deviceId);
+	if(!existing) {
+		add_locked(connection, connect, deviceId, queue);
+		return RegisterResult::Connected;
+	}
+	if(connect.deviceconnect().device().priority() == existing->deviceId->getPriority()) {
+		return RegisterResult::AlreadyConnected;
+	}
+	if(connect.deviceconnect().device().priority() > existing->deviceId->getPriority()) {
+		return RegisterResult::HigherPriorityConnected;
+	}
+	remove_locked(existing, queue);
+	add_locked(connection, connect, deviceId, queue);
+	log::logInfo("Old connection has been removed and replaced with new connection"
+				 " with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {})",
+				 connection->deviceId->getModule(),
+				 connection->deviceId->getDeviceType(),
+				 connection->deviceId->getDeviceRole(),
+				 connection->deviceId->getDeviceName(),
+				 connection->deviceId->getPriority());
+	return RegisterResult::Connected;
+}
+
+void ConnectedDevices::remove(const std::shared_ptr<structures::Connection> &connection,
+							  structures::AtomicQueue<structures::InternalClientMessage> &queue) {
+	std::lock_guard lock(mutex_);
+	remove_locked(connection, queue);
+}
+
+void ConnectedDevices::remove_by_id(const structures::DeviceIdentification &deviceId,
+									structures::AtomicQueue<structures::InternalClientMessage> &queue) {
+	std::lock_guard lock(mutex_);
+	const auto connection = find_locked(deviceId);
+	if(connection) {
+		remove_locked(connection, queue);
+	}
+}
+
+void ConnectedDevices::deliver(
+		const InternalProtocol::InternalServer &message,
+		const structures::DeviceIdentification &deviceId,
+		const std::function<bool(const std::shared_ptr<structures::Connection> &,
+								 const InternalProtocol::InternalServer &)> &send_fn) {
+	std::lock_guard lock(mutex_);
+	const auto connection = find_locked(deviceId);
+	if(connection && connection->deviceId->getPriority() == deviceId.getPriority()) {
+		send_fn(connection, message);
+		{
+			std::lock_guard lk(connection->connectionMutex);
+			connection->ready = true;
+		}
+		connection->conditionVariable.notify_one();
+	}
+}
+
+} // namespace bringauto::internal_server

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -31,6 +31,21 @@ bool send_response(const std::shared_ptr<bringauto::structures::Connection> &con
 	return true;
 }
 
+void respond_with_higher_priority_connected(const std::shared_ptr<bringauto::structures::Connection> &connection,
+											const InternalProtocol::InternalClient &connect,
+											const bringauto::structures::DeviceIdentification &deviceId) {
+	const auto message = bringauto::common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(
+			connect.deviceconnect().device(),
+			InternalProtocol::DeviceConnectResponse_ResponseType_HIGHER_PRIORITY_ALREADY_CONNECTED);
+	log::logInfo(
+			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
+			"cannot be added, same device is already connected with higher priority",
+			deviceId.getModule(),
+			deviceId.getDeviceType(), deviceId.getDeviceRole(),
+			deviceId.getDeviceName(), deviceId.getPriority());
+	send_response(connection, message);
+}
+
 } // namespace
 
 namespace bringauto::internal_server {
@@ -283,7 +298,7 @@ bool InternalServer::handleConnection(const std::shared_ptr<structures::Connecti
 			return false;
 		}
 		if(client.deviceconnect().device().priority() > existingConnection->deviceId->getPriority()) {
-			respondWithHigherPriorityConnected(connection, client, deviceId);
+			respond_with_higher_priority_connected(connection, client, deviceId);
 			return false;
 		}
 		if(client.deviceconnect().device().priority() < existingConnection->deviceId->getPriority()) {
@@ -313,21 +328,6 @@ void InternalServer::connectNewDevice(const std::shared_ptr<structures::Connecti
 			connection->deviceId->getModule(),
 			connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
 			connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
-}
-
-void InternalServer::respondWithHigherPriorityConnected(const std::shared_ptr<structures::Connection> &connection,
-														const InternalProtocol::InternalClient &connect,
-														const structures::DeviceIdentification &deviceId) {
-	const auto message = common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(
-			connect.deviceconnect().device(),
-			InternalProtocol::DeviceConnectResponse_ResponseType_HIGHER_PRIORITY_ALREADY_CONNECTED);
-	log::logInfo(
-			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
-			"cannot be added, same device is already connected with higher priority",
-			deviceId.getModule(),
-			deviceId.getDeviceType(), deviceId.getDeviceRole(),
-			deviceId.getDeviceName(), deviceId.getPriority());
-	send_response(connection, message);
 }
 
 void InternalServer::respondWithAlreadyConnected(const std::shared_ptr<structures::Connection> &connection,

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -6,6 +6,33 @@
 
 
 
+namespace {
+
+using log = bringauto::settings::Logger;
+
+bool send_response(const std::shared_ptr<bringauto::structures::Connection> &connection,
+				   const InternalProtocol::InternalServer &message) {
+	if(not connection->socket.is_open()) {
+		return false;
+	}
+	auto data = message.SerializeAsString();
+	const uint32_t header = data.size();
+	try {
+		boost::asio::write(connection->socket, boost::asio::buffer(&header, sizeof(uint32_t)));
+		log::logDebug("Sending response to Internal Client, "
+					  "connection's ip address is {}",
+					  connection->remoteEndpointAddress());
+		boost::asio::write(connection->socket, boost::asio::buffer(data));
+	} catch(const std::exception &ex) {
+		log::logError("Error in sendResponse(...): "
+					  "Cannot write to Internal Client: {}", ex.what());
+		return false;
+	}
+	return true;
+}
+
+} // namespace
+
 namespace bringauto::internal_server {
 
 using log = settings::Logger;
@@ -300,7 +327,7 @@ void InternalServer::respondWithHigherPriorityConnected(const std::shared_ptr<st
 			deviceId.getModule(),
 			deviceId.getDeviceType(), deviceId.getDeviceRole(),
 			deviceId.getDeviceName(), deviceId.getPriority());
-	sendResponse(connection, message);
+	send_response(connection, message);
 }
 
 void InternalServer::respondWithAlreadyConnected(const std::shared_ptr<structures::Connection> &connection,
@@ -315,7 +342,7 @@ void InternalServer::respondWithAlreadyConnected(const std::shared_ptr<structure
 			deviceId.getModule(),
 			deviceId.getDeviceType(), deviceId.getDeviceRole(),
 			deviceId.getDeviceName(), deviceId.getPriority());
-	sendResponse(connection, message);
+	send_response(connection, message);
 }
 
 void InternalServer::changeConnection(const std::shared_ptr<structures::Connection> &newConnection,
@@ -333,27 +360,6 @@ void InternalServer::changeConnection(const std::shared_ptr<structures::Connecti
 				 newConnection->deviceId->getDeviceRole(),
 				 newConnection->deviceId->getDeviceName(),
 				 newConnection->deviceId->getPriority());
-}
-
-bool InternalServer::sendResponse(const std::shared_ptr<structures::Connection> &connection,
-								  const InternalProtocol::InternalServer &message) {
-	if(not connection->socket.is_open()) {
-		return false;
-	}
-	auto data = message.SerializeAsString();
-	const uint32_t header = data.size();
-	try {
-		boost::asio::write(connection->socket, boost::asio::buffer(&header, sizeof(uint32_t)));
-		log::logDebug("Sending response to Internal Client, "
-					  "connection's ip address is {}",
-					  connection->remoteEndpointAddress());
-		boost::asio::write(connection->socket, boost::asio::buffer(data));
-	} catch(const std::exception &ex) {
-		log::logError("Error in sendResponse(...): "
-					  "Cannot write to Internal Client: {}", ex.what());
-		return false;
-	}
-	return true;
 }
 
 void InternalServer::listenToQueue() {
@@ -382,7 +388,7 @@ void InternalServer::validateResponse(const InternalProtocol::InternalServer &me
 	const auto connection = findConnection(deviceId);
 
 	if(connection && connection->deviceId->getPriority() == deviceId.getPriority()) {
-		sendResponse(connection, message);
+		send_response(connection, message);
 		{
 			std::lock_guard<std::mutex> lk(connection->connectionMutex);
 			connection->ready = true;

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -142,8 +142,7 @@ void InternalServer::asyncReceiveHandler(
 					"Internal Client with ip address {} has been disconnected. Reason: {}",
 					connection->remoteEndpointAddress(), error.message());
 		}
-		std::lock_guard<std::mutex> lock(serverMutex_);
-		removeConnFromMap(connection);
+		connectedDevices_.remove(connection, *fromInternalQueue_);
 		return;
 	}
 
@@ -151,8 +150,7 @@ void InternalServer::asyncReceiveHandler(
 	if(result) {
 		addAsyncReceive(connection);
 	} else {
-		std::lock_guard<std::mutex> lock(serverMutex_);
-		removeConnFromMap(connection);
+		connectedDevices_.remove(connection, *fromInternalQueue_);
 	}
 }
 
@@ -293,7 +291,6 @@ bool InternalServer::handleStatus(const std::shared_ptr<structures::Connection> 
 
 bool InternalServer::handleConnection(const std::shared_ptr<structures::Connection> &connection,
 									  const InternalProtocol::InternalClient &client) {
-	std::lock_guard<std::mutex> lock(serverMutex_);
 	if(connection->ready) {
 		log::logError("Error in handleConnection(...): "
 					  "Internal Client is sending a connect message while already connected, "
@@ -303,63 +300,23 @@ bool InternalServer::handleConnection(const std::shared_ptr<structures::Connecti
 	}
 
 	const structures::DeviceIdentification deviceId { client.deviceconnect().device() };
-	const auto existingConnection = findConnection(deviceId);
+	const auto result = connectedDevices_.try_register(connection, client, deviceId, *fromInternalQueue_);
 
-	if(not existingConnection) {
-		connectNewDevice(connection, client, deviceId);
-	} else {
-		if(client.deviceconnect().device().priority() == existingConnection->deviceId->getPriority()) {
+	switch(result) {
+		case ConnectedDevices::RegisterResult::Connected:
+			return true;
+		case ConnectedDevices::RegisterResult::AlreadyConnected:
 			respond_with_already_connected(connection, client, deviceId);
 			return false;
-		}
-		if(client.deviceconnect().device().priority() > existingConnection->deviceId->getPriority()) {
+		case ConnectedDevices::RegisterResult::HigherPriorityConnected:
 			respond_with_higher_priority_connected(connection, client, deviceId);
 			return false;
-		}
-		if(client.deviceconnect().device().priority() < existingConnection->deviceId->getPriority()) {
-			changeConnection(connection, client, deviceId);
-		}
 	}
 	return true;
 }
 
 void InternalServer::handleDisconnect(const structures::DeviceIdentification& deviceId) {
-	std::lock_guard<std::mutex> lock(serverMutex_);
-	const auto connection = findConnection(deviceId);
-	if(connection) {
-		removeConnFromMap(connection);
-	}
-}
-
-void InternalServer::connectNewDevice(const std::shared_ptr<structures::Connection> &connection,
-									  const InternalProtocol::InternalClient &connect,
-									  const structures::DeviceIdentification &deviceId) {
-	connection->deviceId = std::make_shared<structures::DeviceIdentification>(deviceId);
-	connectedDevices_.push_back(connection);
-	fromInternalQueue_->pushAndNotify(structures::InternalClientMessage(false, connect));
-	log::logInfo(
-			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
-			"has been added into the vector of active connections",
-			connection->deviceId->getModule(),
-			connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
-			connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
-}
-
-void InternalServer::changeConnection(const std::shared_ptr<structures::Connection> &newConnection,
-									  const InternalProtocol::InternalClient &connect,
-									  const structures::DeviceIdentification &deviceId) {
-	const auto oldConnection = findConnection(deviceId);
-	if(oldConnection) {
-		removeConnFromMap(oldConnection);
-	}
-	connectNewDevice(newConnection, connect, deviceId);
-	log::logInfo("Old connection has been removed and replaced with new connection"
-				 " with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {})",
-				 newConnection->deviceId->getModule(),
-				 newConnection->deviceId->getDeviceType(),
-				 newConnection->deviceId->getDeviceRole(),
-				 newConnection->deviceId->getDeviceName(),
-				 newConnection->deviceId->getPriority());
+	connectedDevices_.remove_by_id(deviceId, *fromInternalQueue_);
 }
 
 void InternalServer::listenToQueue() {
@@ -384,54 +341,7 @@ void InternalServer::validateResponse(const InternalProtocol::InternalServer &me
 	if(message.has_deviceconnectresponse()) {
 		deviceId = message.deviceconnectresponse().device();
 	}
-	std::lock_guard<std::mutex> lock(serverMutex_);
-	const auto connection = findConnection(deviceId);
-
-	if(connection && connection->deviceId->getPriority() == deviceId.getPriority()) {
-		send_response(connection, message);
-		{
-			std::lock_guard<std::mutex> lk(connection->connectionMutex);
-			connection->ready = true;
-		}
-		connection->conditionVariable.notify_one();
-	}
-}
-
-void InternalServer::removeConnFromMap(const std::shared_ptr<structures::Connection> &connection) {
-	boost::system::error_code error {};
-	connection->socket.shutdown(boost::asio::socket_base::shutdown_both, error);
-	connection->socket.close(error);
-	if(connection->deviceId == nullptr) {
-		return;
-	}
-	const auto it = std::find_if(connectedDevices_.begin(), connectedDevices_.end(),
-								 [&connection](const std::shared_ptr<structures::Connection> &toCompare) {
-									 return connection->deviceId->isSame(toCompare->deviceId);
-								 });
-
-	if(it != connectedDevices_.end() && (*it)->deviceId->getPriority() == connection->deviceId->getPriority()) {
-		connectedDevices_.erase(it);
-		log::logInfo(
-				"connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {})"
-				" has been closed and erased", connection->deviceId->getModule(),
-				connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
-				connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
-		fromInternalQueue_->pushAndNotify(structures::InternalClientMessage(*connection->deviceId));
-	}
-
-}
-
-std::shared_ptr<structures::Connection>
-InternalServer::findConnection(const structures::DeviceIdentification &deviceId) {
-	std::shared_ptr<structures::Connection> connectionFound {};
-	const auto it = std::find_if(connectedDevices_.begin(), connectedDevices_.end(),
-						   [&deviceId](const auto& toCompare) {
-							   return deviceId.isSame(toCompare->deviceId);
-						   });
-	if(it != connectedDevices_.end()) {
-		connectionFound = *it;
-	}
-	return connectionFound;
+	connectedDevices_.deliver(message, deviceId, send_response);
 }
 
 void InternalServer::destroy() {

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -46,6 +46,21 @@ void respond_with_higher_priority_connected(const std::shared_ptr<bringauto::str
 	send_response(connection, message);
 }
 
+void respond_with_already_connected(const std::shared_ptr<bringauto::structures::Connection> &connection,
+									const InternalProtocol::InternalClient &connect,
+									const bringauto::structures::DeviceIdentification &deviceId) {
+	const auto message = bringauto::common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(
+			connect.deviceconnect().device(),
+			InternalProtocol::DeviceConnectResponse_ResponseType_ALREADY_CONNECTED);
+	log::logInfo(
+			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
+			"cannot be added, same device with same priority is already connected",
+			deviceId.getModule(),
+			deviceId.getDeviceType(), deviceId.getDeviceRole(),
+			deviceId.getDeviceName(), deviceId.getPriority());
+	send_response(connection, message);
+}
+
 } // namespace
 
 namespace bringauto::internal_server {
@@ -294,7 +309,7 @@ bool InternalServer::handleConnection(const std::shared_ptr<structures::Connecti
 		connectNewDevice(connection, client, deviceId);
 	} else {
 		if(client.deviceconnect().device().priority() == existingConnection->deviceId->getPriority()) {
-			respondWithAlreadyConnected(connection, client, deviceId);
+			respond_with_already_connected(connection, client, deviceId);
 			return false;
 		}
 		if(client.deviceconnect().device().priority() > existingConnection->deviceId->getPriority()) {
@@ -328,21 +343,6 @@ void InternalServer::connectNewDevice(const std::shared_ptr<structures::Connecti
 			connection->deviceId->getModule(),
 			connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
 			connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
-}
-
-void InternalServer::respondWithAlreadyConnected(const std::shared_ptr<structures::Connection> &connection,
-												 const InternalProtocol::InternalClient &connect,
-												 const structures::DeviceIdentification &deviceId) {
-	const auto message = common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(
-			connect.deviceconnect().device(),
-			InternalProtocol::DeviceConnectResponse_ResponseType_ALREADY_CONNECTED);
-	log::logInfo(
-			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
-			"cannot be added, same device with same priority is already connected",
-			deviceId.getModule(),
-			deviceId.getDeviceType(), deviceId.getDeviceRole(),
-			deviceId.getDeviceName(), deviceId.getPriority());
-	send_response(connection, message);
 }
 
 void InternalServer::changeConnection(const std::shared_ptr<structures::Connection> &newConnection,


### PR DESCRIPTION
Extract the connected-device registry into a new `ConnectedDevices` class, moving three helper free functions (`send_response`, `respond_with_higher_priority_connected`, `respond_with_already_connected`) to the anonymous namespace in `InternalServer.cpp`. All four compound registry operations (find+register, find+remove, find+deliver) are now encapsulated as single atomic methods in `ConnectedDevices`, eliminating the need for callers to hold `serverMutex_` directly. Note: `respond_with_*` calls now execute after the registry mutex is released (previously they ran while holding `serverMutex_`); the `is_open()` guard in `send_response` makes this safe since each connection has at most one receive thread.