### PR TITLE
Immediate command forwarding via module-controlled forward_command_on_receive

### DIFF
--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -24,7 +24,8 @@ public:
 
 	ExternalClient(const std::shared_ptr<structures::GlobalContext> &context,
 				   structures::ModuleLibrary &moduleLibrary,
-				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue);
+				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
+				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue);
 
 	/**
 	 * @brief Initialize connections, error aggregators
@@ -95,10 +96,12 @@ private:
 	std::unordered_map<unsigned int, std::reference_wrapper<connection::ExternalConnection>> externalConnectionMap_ {};
 	/// List of external connections, each device can have its own connection or multiple devices can share one connection
 	std::list<connection::ExternalConnection> externalConnectionsList_ {};
-	/// Queue for  messages from module handler to external client to be sent to external server
+	/// Queue for messages from module handler to external client to be sent to external server
 	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> toExternalQueue_;
 	/// Queue for device commands received by external client to module handler
 	std::shared_ptr<structures::AtomicQueue<InternalProtocol::DeviceCommand>> fromExternalQueue_ {};
+	/// Queue shared with ModuleHandler; used to push command-forward events for immediate dispatch
+	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
 
 	std::shared_ptr<structures::AtomicQueue<structures::ReconnectQueueItem>> reconnectQueue_ {};
 

--- a/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
+++ b/include/bringauto/modules/IModuleManagerLibraryHandler.hpp
@@ -2,6 +2,7 @@
 
 #include <bringauto/modules/Buffer.hpp>
 
+#include <fleet_protocol/common_headers/general_error_codes.h>
 #include <fleet_protocol/common_headers/memory_management.h>
 
 #include <functional>
@@ -102,6 +103,17 @@ public:
 	 * @return OK if valid, NOT_OK otherwise
 	 */
 	virtual int commandDataValid(const Buffer &command, unsigned int device_type) const = 0;
+
+	/**
+	 * @brief Determine whether Module Gateway should forward a received command to the device
+	 * immediately upon receipt, without waiting for the next status message.
+	 *
+	 * Optional — modules that do not implement this default to NOT_OK (existing behaviour).
+	 *
+	 * @param device_type device type
+	 * @return OK to forward immediately, NOT_OK to forward on next status
+	 */
+	virtual int forwardCommandOnReceive(unsigned int /*device_type*/) { return NOT_OK; }
 
 	/**
 	 * @brief Constructs a buffer with the given size

--- a/include/bringauto/modules/ModuleHandler.hpp
+++ b/include/bringauto/modules/ModuleHandler.hpp
@@ -19,11 +19,12 @@ public:
 			const std::shared_ptr <structures::GlobalContext> &context,
 			structures::ModuleLibrary &moduleLibrary,
 			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &fromInternalQueue,
+			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue,
 			const std::shared_ptr <structures::AtomicQueue<structures::ModuleHandlerMessage>> &toInternalQueue,
 			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue)
-			: context_ { context }, moduleLibrary_ { moduleLibrary }, fromInternalQueue_ { fromInternalQueue },
-			  toInternalQueue_ { toInternalQueue },
-			  toExternalQueue_ { toExternalQueue } {}
+			: context_ { context }, moduleLibrary_ { moduleLibrary },
+			  fromInternalQueue_ { fromInternalQueue }, commandForwardingQueue_ { commandForwardingQueue },
+			  toInternalQueue_ { toInternalQueue }, toExternalQueue_ { toExternalQueue } {}
 
 	/**
 	 * @brief Start Module handler
@@ -46,6 +47,12 @@ private:
 	 *
 	 */
 	void handleMessages() const;
+
+	/**
+	 * @brief Process command-forward events from ExternalClient independently of handleMessages.
+	 * Runs in its own thread started by run().
+	 */
+	void handleCommandForwards() const;
 
 	/**
 	 * @brief Check if there are any timeouted messages
@@ -92,6 +99,14 @@ private:
 	void handleStatus(const InternalProtocol::DeviceStatus &status) const;
 
 	/**
+	 * @brief Forward a pending command to a device immediately, using the cached status.
+	 * Triggered when ExternalClient receives a command for a module with forward_command_on_receive enabled.
+	 *
+	 * @param deviceId device that has a command pending in the external command queue
+	 */
+	void handleCommandForward(const structures::DeviceIdentification &deviceId) const;
+
+	/**
 	 * @brief Throws an error if external queue size is too big
 	 */
 	void checkExternalQueueSize() const;
@@ -99,8 +114,10 @@ private:
 	std::shared_ptr <structures::GlobalContext> context_ {};
 
 	structures::ModuleLibrary &moduleLibrary_;
-	/// Queue for incoming messages from internal server to be processed
+	/// Queue for incoming messages from internal server (connect/status/disconnect)
 	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> fromInternalQueue_ {};
+	/// Queue for command-forward events from external client
+	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
 	/// Queue for outgoing messages to internal server to be forwarded to devices
 	std::shared_ptr <structures::AtomicQueue<structures::ModuleHandlerMessage>> toInternalQueue_ {};
 	/// Queue for outgoing messages to external server to be forwarded to external server

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerAsync.hpp
@@ -78,6 +78,8 @@ public:
 
 	int commandDataValid(const Buffer &command, unsigned int device_type) const override;
 
+	int forwardCommandOnReceive(unsigned int device_type) override;
+
 	/**
 	 * @brief Constructs a buffer with the given size
 	 *

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
@@ -53,6 +53,8 @@ public:
 
 	int commandDataValid(const Buffer &command, unsigned int device_type) const override;
 
+	int forwardCommandOnReceive(unsigned int device_type) override;
+
 	/**
 	 * @brief Constructs a buffer with the given size
 	 *
@@ -68,6 +70,12 @@ private:
 	void deallocate(struct buffer *buffer) const;
 
 	void *checkFunction(const char *functionName) const;
+
+	/**
+	 * @brief Look up an optional symbol in the loaded library.
+	 * @return function pointer, or nullptr if the symbol is not exported
+	 */
+	void *checkOptionalFunction(const char *functionName) const;
 
 	/**
 	 * @brief Constructs a buffer with the same raw c buffer as provided
@@ -93,6 +101,8 @@ private:
 	std::function<int(struct buffer *, struct buffer, struct buffer, struct buffer, unsigned int)> generateCommand_ {};
 	std::function<int(struct buffer *, size_t)> allocate_ {};
 	std::function<void(struct buffer *)> deallocate_ {};
+	/// Optional — nullptr when the module does not export forward_command_on_receive
+	std::function<int(unsigned int)> forwardCommandOnReceive_ {};
 };
 
 }

--- a/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
+++ b/include/bringauto/modules/ModuleManagerLibraryHandlerLocal.hpp
@@ -6,6 +6,9 @@
 
 namespace bringauto::modules {
 
+/// Generic function pointer type used as the return type of dlsym lookups.
+using FunctionPtr = void(*)();
+
 /**
  * @brief Class used to load and handle library created by module maintainer
  */
@@ -69,13 +72,13 @@ private:
 
 	void deallocate(struct buffer *buffer) const;
 
-	void *checkFunction(const char *functionName) const;
+	FunctionPtr checkFunction(const char *functionName) const;
 
 	/**
 	 * @brief Look up an optional symbol in the loaded library.
 	 * @return function pointer, or nullptr if the symbol is not exported
 	 */
-	void *checkOptionalFunction(const char *functionName) const;
+	FunctionPtr checkOptionalFunction(const char *functionName) const;
 
 	/**
 	 * @brief Constructs a buffer with the same raw c buffer as provided

--- a/include/bringauto/modules/StatusAggregator.hpp
+++ b/include/bringauto/modules/StatusAggregator.hpp
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 #include <list>
+#include <mutex>
 
 
 
@@ -116,6 +117,16 @@ public:
 					Buffer &command);
 
 	/**
+	 * @brief Get a command for immediate forwarding, using the cached status as input.
+	 * Called when a command arrived and the module requested immediate forwarding.
+	 *
+	 * @param device device identification
+	 * @param command output buffer for the generated command
+	 * @return OK on success, DEVICE_NOT_REGISTERED or COMMAND_INVALID on error
+	 */
+	int get_command_for_forwarding(const structures::DeviceIdentification& device, Buffer& command);
+
+	/**
 	 * @short Get number of the module
 	 *
 	 * @see fleet-protocol/lib/common_headers/include/device_management.h
@@ -197,6 +208,9 @@ private:
 	 * @brief Map of devices timeouts, key is DeviceIdentification
 	 */
 	std::unordered_map<structures::DeviceIdentification, int> deviceTimeouts_ {};
+
+	/// Protects devices and deviceTimeouts_ against concurrent access from ModuleHandler threads and ExternalClient
+	mutable std::recursive_mutex devicesMutex_ {};
 
 	std::atomic_bool timeoutedMessageReady_ { false };
 };

--- a/include/bringauto/modules/StatusAggregator.hpp
+++ b/include/bringauto/modules/StatusAggregator.hpp
@@ -122,7 +122,8 @@ public:
 	 *
 	 * @param device device identification
 	 * @param command output buffer for the generated command
-	 * @return OK on success, DEVICE_NOT_REGISTERED or COMMAND_INVALID on error
+	 * @return OK on success; NO_MESSAGE_AVAILABLE when no pending command;
+	 *         DEVICE_NOT_REGISTERED, DEVICE_NOT_SUPPORTED, or COMMAND_INVALID on error
 	 */
 	int get_command_for_forwarding(const structures::DeviceIdentification& device, Buffer& command);
 

--- a/include/bringauto/modules/StatusAggregator.hpp
+++ b/include/bringauto/modules/StatusAggregator.hpp
@@ -164,6 +164,40 @@ public:
 private:
 
 	/**
+	 * @brief Check if device is valid without acquiring devicesMutex_. Caller must hold the lock.
+	 *
+	 * @param device device identification
+	 * @return OK if device is registered and its type is supported, NOT_OK otherwise
+	 */
+	int isDeviceValidUnlocked(const structures::DeviceIdentification& device);
+
+	/**
+	 * @brief Force status message aggregation on a device without acquiring devicesMutex_. Caller must hold the lock.
+	 *
+	 * @param device device identification
+	 * @return number of queued aggregated messages on success, DEVICE_NOT_REGISTERED if device is unknown
+	 */
+	int forceAggregationOnDeviceUnlocked(const structures::DeviceIdentification& device);
+
+	/**
+	 * @brief Clear state and messages for a device without acquiring devicesMutex_. Caller must hold the lock.
+	 *
+	 * @param device device identification
+	 * @return OK on success, DEVICE_NOT_REGISTERED if device is unknown
+	 */
+	int clearDeviceUnlocked(const structures::DeviceIdentification& device);
+
+	/**
+	 * @brief Get command for a device without acquiring devicesMutex_. Caller must hold the lock.
+	 *
+	 * @param status current status buffer
+	 * @param device device identification
+	 * @param command output buffer for the generated command
+	 * @return OK on success, DEVICE_NOT_SUPPORTED, NO_MESSAGE_AVAILABLE, or COMMAND_INVALID on error
+	 */
+	int getCommandUnlocked(const Buffer& status, const structures::DeviceIdentification& device, Buffer& command);
+
+	/**
 	 * @brief Aggregate status message
 	 *
 	 * @param deviceState device state
@@ -210,7 +244,7 @@ private:
 	std::unordered_map<structures::DeviceIdentification, int> deviceTimeouts_ {};
 
 	/// Protects devices and deviceTimeouts_ against concurrent access from ModuleHandler threads and ExternalClient
-	mutable std::recursive_mutex devicesMutex_ {};
+	mutable std::mutex devicesMutex_ {};
 
 	std::atomic_bool timeoutedMessageReady_ { false };
 };

--- a/include/bringauto/structures/InternalClientMessage.hpp
+++ b/include/bringauto/structures/InternalClientMessage.hpp
@@ -19,6 +19,15 @@ public:
 		deviceId_ { deviceId }
 	{}
 
+	/**
+	 * @brief Create a command-forward event. Used by ExternalClient to wake up ModuleHandler
+	 * for immediate command dispatch when the module requested forward_command_on_receive.
+	 *
+	 * @param deviceId device that has a pending command to forward
+	 * @return InternalClientMessage tagged as command-forward
+	 */
+	static InternalClientMessage makeCommandForward(const DeviceIdentification &deviceId);
+
 	explicit InternalClientMessage(bool disconnect, const InternalProtocol::InternalClient &message):
 		message_ { message },
 		disconnect_ { disconnect }
@@ -45,6 +54,11 @@ public:
 	bool disconnected() const;
 
 	/**
+	 * @brief Returns true if this message is a command-forward event (no protobuf payload).
+	 */
+	[[nodiscard]] bool isCommandForward() const noexcept;
+
+	/**
 	 * @brief Get device identification struct
 	 *
 	 * @return const DeviceIdentification&
@@ -52,10 +66,16 @@ public:
 	const DeviceIdentification &getDeviceId() const;
 
 private:
+	InternalClientMessage(const DeviceIdentification &deviceId, bool commandForward)
+		: disconnect_ { false }, commandForward_ { commandForward }, deviceId_ { deviceId }
+	{}
+
 	/// Internal client message
 	InternalProtocol::InternalClient message_ {};
 	/// True if device is disconnected otherwise false
 	bool disconnect_;
+	/// True if this is a command-forward event (no protobuf payload)
+	bool commandForward_ { false };
 	/// Device identification struct
 	DeviceIdentification deviceId_ {};
 };

--- a/include/bringauto/structures/StatusAggregatorDeviceState.hpp
+++ b/include/bringauto/structures/StatusAggregatorDeviceState.hpp
@@ -6,6 +6,7 @@
 #include <bringauto/modules/Buffer.hpp>
 
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <memory>
 
@@ -55,14 +56,17 @@ public:
 	void setDefaultCommand(const modules::Buffer &commandBuffer);
 
 	/**
-	 * @brief Gets the most relevant command buffer.
-	 * If there are external commands in the queue, they will be used first.
-	 * Otherwise, the default command buffer will be used.
-	 * Commands received from the queue are removed from it.
+	 * @brief Consumes and returns the most relevant command buffer.
+	 * If there are external commands in the queue, they will be dequeued and returned.
+	 * For push-only devices (forwardCommandOnReceive == OK) with an empty queue,
+	 * returns std::nullopt — the caller must send an empty DeviceCommand to satisfy the
+	 * InternalProtocol response requirement without forwarding anything to the vehicle.
+	 * For pull devices, falls back to the default command buffer when the queue is empty.
+	 * Commands dequeued from the external queue are removed from it.
 	 *
-	 * @return const Buffer&
+	 * @return command buffer, or std::nullopt when push-only device has no pending command
 	 */
-	[[nodiscard]] const modules::Buffer &getCommand();
+	[[nodiscard]] std::optional<modules::Buffer> consumeCommand();
 
 	/**
 	 * @brief Get aggregated messages queue

--- a/include/bringauto/structures/StatusAggregatorDeviceState.hpp
+++ b/include/bringauto/structures/StatusAggregatorDeviceState.hpp
@@ -80,6 +80,17 @@ public:
 	 */
 	int addExternalCommand(const modules::Buffer &commandBuffer);
 
+	/**
+	 * @brief Mark this device as requiring immediate command forwarding.
+	 * Called once at device registration based on the module's forwardCommandOnReceive response.
+	 */
+	void enableImmediateCommandForwarding() noexcept;
+
+	/**
+	 * @brief Returns true if this device requires commands to be forwarded immediately upon receipt.
+	 */
+	[[nodiscard]] bool isForwardCommandImmediately() const noexcept;
+
 private:
 	std::unique_ptr<ThreadTimer> timer_ {};
 
@@ -92,6 +103,8 @@ private:
 	std::unique_ptr<std::mutex> externalCommandMutex_ { std::make_unique<std::mutex>() };
 
 	std::queue<modules::Buffer> externalCommandQueue_ {};
+
+	bool forwardCommandImmediately_ { false };
 };
 
 }

--- a/include/bringauto/structures/StatusAggregatorDeviceState.hpp
+++ b/include/bringauto/structures/StatusAggregatorDeviceState.hpp
@@ -104,7 +104,7 @@ private:
 
 	modules::Buffer defaultCommand_ {};
 
-	std::unique_ptr<std::mutex> externalCommandMutex_ { std::make_unique<std::mutex>() };
+	std::mutex externalCommandMutex_ {};
 
 	std::queue<modules::Buffer> externalCommandQueue_ {};
 

--- a/include/bringauto/structures/StatusAggregatorDeviceState.hpp
+++ b/include/bringauto/structures/StatusAggregatorDeviceState.hpp
@@ -5,6 +5,7 @@
 #include <bringauto/structures/DeviceIdentification.hpp>
 #include <bringauto/modules/Buffer.hpp>
 
+#include <mutex>
 #include <queue>
 #include <memory>
 
@@ -87,6 +88,8 @@ private:
 	modules::Buffer status_ {};
 
 	modules::Buffer defaultCommand_ {};
+
+	std::unique_ptr<std::mutex> externalCommandMutex_ { std::make_unique<std::mutex>() };
 
 	std::queue<modules::Buffer> externalCommandQueue_ {};
 };

--- a/main.cpp
+++ b/main.cpp
@@ -77,12 +77,13 @@ int main(int argc, char **argv) {
 
 	auto toInternalQueue = std::make_shared<bas::AtomicQueue<bas::ModuleHandlerMessage >>();
 	auto fromInternalQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
+	auto commandForwardingQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
 	auto toExternalQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
 
 	bais::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
-	bringauto::modules::ModuleHandler moduleHandler { context, moduleLibrary, fromInternalQueue, toInternalQueue,
-													  toExternalQueue };
-	bringauto::external_client::ExternalClient externalClient { context, moduleLibrary, toExternalQueue };
+	bringauto::modules::ModuleHandler moduleHandler { context, moduleLibrary, fromInternalQueue,
+													  commandForwardingQueue, toInternalQueue, toExternalQueue };
+	bringauto::external_client::ExternalClient externalClient { context, moduleLibrary, toExternalQueue, commandForwardingQueue };
 
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.run(); });
 	std::jthread externalClientThread([&externalClient]() { externalClient.run(); });

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -8,6 +8,7 @@
 #include <bringauto/settings/LoggerId.hpp>
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
+#include <fleet_protocol/module_gateway/error_codes.h>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
@@ -20,8 +21,10 @@ namespace ip = InternalProtocol;
 
 ExternalClient::ExternalClient(const std::shared_ptr<structures::GlobalContext> &context,
 							   structures::ModuleLibrary &moduleLibrary,
-							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue):
+							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
+							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue):
 		toExternalQueue_ { toExternalQueue },
+		commandForwardingQueue_ { commandForwardingQueue },
 		context_ { context },
 		moduleLibrary_ { moduleLibrary },
 		timer_ { context->ioContext } {
@@ -65,8 +68,11 @@ void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &device
 
 
 	const auto deviceId = structures::DeviceIdentification(device);
-	int ret = it->second->update_command(commandBuffer, deviceId);
-	if (ret == OK) {
+	const int ret = it->second->update_command(commandBuffer, deviceId);
+	if (ret == FORWARD_IMMEDIATELY) {
+		settings::Logger::logInfo("Command for device {} was added to queue, forwarding immediately", device.devicename());
+		commandForwardingQueue_->pushAndNotify(structures::InternalClientMessage::makeCommandForward(deviceId));
+	} else if (ret == OK) {
 		settings::Logger::logInfo("Command for device {} was added to queue", device.devicename());
 	}
 }

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -69,11 +69,13 @@ void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &device
 
 	const auto deviceId = structures::DeviceIdentification(device);
 	const int ret = it->second->update_command(commandBuffer, deviceId);
-	if (ret == FORWARD_IMMEDIATELY) {
-		settings::Logger::logInfo("Command for device {} was added to queue, forwarding immediately", device.devicename());
-		commandForwardingQueue_->pushAndNotify(structures::InternalClientMessage::makeCommandForward(deviceId));
-	} else if (ret == OK) {
-		settings::Logger::logInfo("Command for device {} was added to queue", device.devicename());
+	if (ret == OK) {
+		if (moduleLibraryHandler->forwardCommandOnReceive(deviceId.getDeviceType()) == OK) {
+			settings::Logger::logInfo("Command for device {} was added to queue, forwarding immediately", device.devicename());
+			commandForwardingQueue_->pushAndNotify(structures::InternalClientMessage::makeCommandForward(deviceId));
+		} else {
+			settings::Logger::logInfo("Command for device {} was added to queue", device.devicename());
+		}
 	}
 }
 

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -102,12 +102,11 @@ void InternalServer::asyncReceiveHandler(
 bool InternalServer::processBufferData(
 		const std::shared_ptr<structures::Connection> &connection,
 		std::size_t bytesTransferred, std::size_t bufferOffset) {
-	if(bytesTransferred < bufferOffset) {
+	if(bufferOffset + bytesTransferred > connection->connContext.buffer.size()) {
 		log::logError(
-				"Error in processBufferData(...): bufferOffset: {} is greater than bytesTransferred: {}, "
-				"Invalid bufferOffset: {} received from Internal Client, "
-				"connection's ip address is {}", bufferOffset, bytesTransferred, bufferOffset,
-				connection->remoteEndpointAddress());
+				"Error in processBufferData(...): bufferOffset: {} + bytesTransferred: {} exceeds buffer size: {}, "
+				"connection's ip address is {}", bufferOffset, bytesTransferred,
+				connection->connContext.buffer.size(), connection->remoteEndpointAddress());
 		return false;
 	}
 
@@ -170,7 +169,7 @@ bool InternalServer::processBufferData(
 					  connection->remoteEndpointAddress());
 		return false;
 	}
-	if(bytesLeft && !processBufferData(connection, bytesLeft, bytesTransferred - bytesLeft)) {
+	if(bytesLeft && !processBufferData(connection, bytesLeft, bufferOffset + (bytesTransferred - bytesLeft))) {
 		log::logError("Error in processBufferData(...): "
 					  "Received extra invalid bytes of data: {} from Internal Client, "
 					  "connection's ip address is {}", bytesLeft,

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -5,6 +5,8 @@
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
 
+#include <thread>
+
 
 
 namespace bringauto::modules {
@@ -15,12 +17,16 @@ void ModuleHandler::destroy() const {
 	while(not fromInternalQueue_->empty()) {
 		fromInternalQueue_->pop();
 	}
+	while(not commandForwardingQueue_->empty()) {
+		commandForwardingQueue_->pop();
+	}
 	settings::Logger::logInfo("Module handler stopped");
 }
 
 void ModuleHandler::run() const {
 	settings::Logger::logInfo("Module handler started, constants used: queue_timeout_length: {}, status_aggregation_timeout: {}",
 				 settings::queue_timeout_length.count(), settings::status_aggregation_timeout.count());
+	std::jthread forwardThread([this]() { handleCommandForwards(); });
 	handleMessages();
 }
 
@@ -41,6 +47,16 @@ void ModuleHandler::handleMessages() const {
 			handleStatus(message.getMessage().devicestatus());
 		}
 		fromInternalQueue_->pop();
+	}
+}
+
+void ModuleHandler::handleCommandForwards() const {
+	while(not context_->ioContext.stopped()) {
+		if(commandForwardingQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+			continue;
+		}
+		handleCommandForward(commandForwardingQueue_->front().getDeviceId());
+		commandForwardingQueue_->pop();
 	}
 }
 
@@ -154,6 +170,27 @@ ModuleHandler::sendConnectResponse(const ip::Device &device, ip::DeviceConnectRe
 	const auto response = common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(device, response_type);
 	toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false,response));
 	settings::Logger::logInfo("New device {} is trying to connect, sending response {}", device.devicename(), static_cast<int>(response_type));
+}
+
+void ModuleHandler::handleCommandForward(const structures::DeviceIdentification &deviceId) const {
+	const auto &moduleNumber = deviceId.getModule();
+	const auto &statusAggregators = moduleLibrary_.statusAggregators;
+	if(not statusAggregators.contains(moduleNumber)) {
+		settings::Logger::logWarning("Module number: {} is not supported in handleCommandForward", moduleNumber);
+		return;
+	}
+
+	const auto &statusAggregator = statusAggregators.at(moduleNumber);
+	Buffer commandBuffer {};
+	if(statusAggregator->get_command_for_forwarding(deviceId, commandBuffer) != OK) {
+		settings::Logger::logWarning("get_command_for_forwarding failed for device: {}", deviceId.getDeviceName());
+		return;
+	}
+
+	const auto device = deviceId.convertToIPDevice();
+	const auto deviceCommandMessage = common_utils::ProtobufUtils::createInternalServerCommandMessage(device, commandBuffer);
+	toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
+	settings::Logger::logDebug("Module handler forwarded command immediately for device: {}", deviceId.getDeviceName());
 }
 
 void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -4,6 +4,7 @@
 #include <bringauto/common_utils/ProtobufUtils.hpp>
 
 #include <fleet_protocol/common_headers/general_error_codes.h>
+#include <fleet_protocol/module_gateway/error_codes.h>
 
 #include <thread>
 
@@ -182,7 +183,12 @@ void ModuleHandler::handleCommandForward(const structures::DeviceIdentification 
 
 	const auto &statusAggregator = statusAggregators.at(moduleNumber);
 	Buffer commandBuffer {};
-	if(statusAggregator->get_command_for_forwarding(deviceId, commandBuffer) != OK) {
+	const int forwardRc = statusAggregator->get_command_for_forwarding(deviceId, commandBuffer);
+	if(forwardRc == NO_MESSAGE_AVAILABLE) {
+		settings::Logger::logDebug("Command already consumed by status path for push-only device: {}", deviceId.getDeviceName());
+		return;
+	}
+	if(forwardRc != OK) {
 		settings::Logger::logWarning("get_command_for_forwarding failed for device: {}", deviceId.getDeviceName());
 		return;
 	}
@@ -233,6 +239,15 @@ void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {
 																									commandBuffer);
 		toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
 		settings::Logger::logDebug("Module handler successfully retrieved command and sent it to device: {}", deviceName);
+	} else if(getCommandRc == NO_MESSAGE_AVAILABLE) {
+		// Push-only device with no fresh command from ES. Send an empty DeviceCommand to
+		// satisfy the InternalProtocol 250ms response requirement. The bridge will detect
+		// empty commanddata and not forward it to the vehicle, letting the vehicle's own
+		// timeout trigger the safe-stop.
+		const auto emptyCommandMessage = common_utils::ProtobufUtils::createInternalServerCommandMessage(
+			device, Buffer{});
+		toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, emptyCommandMessage));
+		settings::Logger::logDebug("No fresh command for push-only device {}, sending empty response", deviceName);
 	} else {
 		settings::Logger::logWarning("Retrieving command failed with return code: {}", getCommandRc);
 		return;

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerAsync.cpp
@@ -210,6 +210,10 @@ int ModuleManagerLibraryHandlerAsync::commandDataValid(const Buffer &command, un
 	return aeronClient_.callFunc(fp_async::commandDataValidAsync, command_raw_buffer, device_type).value_or(NOT_OK);
 }
 
+int ModuleManagerLibraryHandlerAsync::forwardCommandOnReceive(unsigned int /*device_type*/) {
+	return NOT_OK;
+}
+
 Buffer ModuleManagerLibraryHandlerAsync::constructBuffer(std::size_t size) {
 	if(size == 0) {
 		return Buffer {};

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -57,6 +57,11 @@ void ModuleManagerLibraryHandlerLocal::loadLibrary(const std::filesystem::path &
 			"allocate"));
 	deallocate_ = reinterpret_cast<FunctionTypeDeducer<decltype(deallocate_)>::fncptr>(checkFunction(
 			"deallocate"));
+	forwardCommandOnReceive_ = reinterpret_cast<FunctionTypeDeducer<decltype(forwardCommandOnReceive_)>::fncptr>(
+			checkOptionalFunction("forward_command_on_receive"));
+	if(forwardCommandOnReceive_) {
+		log::logDebug("Library " + path.string() + " supports forward_command_on_receive");
+	}
 	log::logDebug("Library " + path.string() + " was successfully loaded");
 }
 
@@ -66,6 +71,10 @@ void *ModuleManagerLibraryHandlerLocal::checkFunction(const char *functionName) 
 		throw std::runtime_error {"Function " + std::string(functionName) + " is not included in library"};
 	}
 	return function;
+}
+
+void *ModuleManagerLibraryHandlerLocal::checkOptionalFunction(const char *functionName) const {
+	return dlsym(module_, functionName);
 }
 
 int ModuleManagerLibraryHandlerLocal::getModuleNumber() const {
@@ -194,6 +203,13 @@ int ModuleManagerLibraryHandlerLocal::commandDataValid(const Buffer &command, un
 		raw_buffer = command.getStructBuffer();
 	}
 	return commandDataValid_(raw_buffer, device_type);
+}
+
+int ModuleManagerLibraryHandlerLocal::forwardCommandOnReceive(unsigned int device_type) {
+	if(!forwardCommandOnReceive_) {
+		return NOT_OK;
+	}
+	return forwardCommandOnReceive_(device_type);
 }
 
 int ModuleManagerLibraryHandlerLocal::allocate(struct buffer *buffer_pointer, size_t size_in_bytes) const {

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -66,7 +66,7 @@ void ModuleManagerLibraryHandlerLocal::loadLibrary(const std::filesystem::path &
 }
 
 FunctionPtr ModuleManagerLibraryHandlerLocal::checkFunction(const char *functionName) const {
-	const auto function = reinterpret_cast<FunctionPtr>(dlsym(module_, functionName));
+	const auto function = reinterpret_cast<FunctionPtr>(dlsym(module_, functionName)); // NOSONAR
 	if(not function) {
 		throw std::runtime_error {"Function " + std::string(functionName) + " is not included in library"};
 	}
@@ -74,7 +74,7 @@ FunctionPtr ModuleManagerLibraryHandlerLocal::checkFunction(const char *function
 }
 
 FunctionPtr ModuleManagerLibraryHandlerLocal::checkOptionalFunction(const char *functionName) const {
-	return reinterpret_cast<FunctionPtr>(dlsym(module_, functionName));
+	return reinterpret_cast<FunctionPtr>(dlsym(module_, functionName)); // NOSONAR
 }
 
 int ModuleManagerLibraryHandlerLocal::getModuleNumber() const {

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -57,7 +57,7 @@ void ModuleManagerLibraryHandlerLocal::loadLibrary(const std::filesystem::path &
 			"allocate"));
 	deallocate_ = reinterpret_cast<FunctionTypeDeducer<decltype(deallocate_)>::fncptr>(checkFunction(
 			"deallocate"));
-	forwardCommandOnReceive_ = reinterpret_cast<FunctionTypeDeducer<decltype(forwardCommandOnReceive_)>::fncptr>(
+	forwardCommandOnReceive_ = reinterpret_cast<FunctionTypeDeducer<decltype(forwardCommandOnReceive_)>::fncptr>( // NOSONAR: dlsym returns void* by POSIX API contract; reinterpret_cast to function pointer is unavoidable here
 			checkOptionalFunction("forward_command_on_receive"));
 	if(forwardCommandOnReceive_) {
 		log::logDebug("Library " + path.string() + " supports forward_command_on_receive");

--- a/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
+++ b/source/bringauto/modules/ModuleManagerLibraryHandlerLocal.cpp
@@ -65,16 +65,16 @@ void ModuleManagerLibraryHandlerLocal::loadLibrary(const std::filesystem::path &
 	log::logDebug("Library " + path.string() + " was successfully loaded");
 }
 
-void *ModuleManagerLibraryHandlerLocal::checkFunction(const char *functionName) const {
-	const auto function = dlsym(module_, functionName);
+FunctionPtr ModuleManagerLibraryHandlerLocal::checkFunction(const char *functionName) const {
+	const auto function = reinterpret_cast<FunctionPtr>(dlsym(module_, functionName));
 	if(not function) {
 		throw std::runtime_error {"Function " + std::string(functionName) + " is not included in library"};
 	}
 	return function;
 }
 
-void *ModuleManagerLibraryHandlerLocal::checkOptionalFunction(const char *functionName) const {
-	return dlsym(module_, functionName);
+FunctionPtr ModuleManagerLibraryHandlerLocal::checkOptionalFunction(const char *functionName) const {
+	return reinterpret_cast<FunctionPtr>(dlsym(module_, functionName));
 }
 
 int ModuleManagerLibraryHandlerLocal::getModuleNumber() const {

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -105,8 +105,9 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 		const std::function<int(const structures::DeviceIdentification&)> timeouted_force_aggregation = [this](
 				const structures::DeviceIdentification& deviceId) {
 					timeoutedMessageReady_.store(true);
+					std::lock_guard lock(devicesMutex_);
 					deviceTimeouts_[deviceId]++;
-					return force_aggregation_on_device(deviceId);
+					return forceAggregationOnDeviceUnlocked(deviceId);
 		};
 		devices.try_emplace(device, context_, timeouted_force_aggregation, device, commandBuffer, status);
 

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -10,6 +10,7 @@ namespace bringauto::modules {
 using log = settings::Logger;
 
 int StatusAggregator::clear_device(const structures::DeviceIdentification &device) {
+	std::lock_guard lock(devicesMutex_);
 	if(is_device_valid(device) == NOT_OK) {
 		return DEVICE_NOT_REGISTERED;
 	}
@@ -59,6 +60,7 @@ int StatusAggregator::destroy_status_aggregator() {
 }
 
 int StatusAggregator::clear_all_devices() {
+	std::lock_guard lock(devicesMutex_);
 	for(auto &[key, device]: devices) {
 		clear_device(key);
 	}
@@ -66,18 +68,22 @@ int StatusAggregator::clear_all_devices() {
 }
 
 int StatusAggregator::remove_device(const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	if(is_device_valid(device) == NOT_OK) {
 		return DEVICE_NOT_REGISTERED;
 	}
 	clear_device(device);
 
-	// WUT, maybe becose there can be multiple context running so by this we ensure no rece condition?
-	boost::asio::post(context_->ioContext, [this, device]() { devices.erase(device); });
+	boost::asio::post(context_->ioContext, [this, device]() {
+		std::lock_guard postLock(devicesMutex_);
+		devices.erase(device);
+	});
 	return OK;
 }
 
 int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 											   const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	const auto &device_type = device.getDeviceType();
 	if(is_device_type_supported(device_type) == NOT_OK) {
 		log::logError("Trying to add status to unsupported device type: {}", device_type);
@@ -101,6 +107,13 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 		devices.emplace(
 				device, structures::StatusAggregatorDeviceState(context_, timeouted_force_aggregation, device, commandBuffer, status));
 
+		const int forwardOnReceive = module_->forwardCommandOnReceive(device_type);
+		log::logInfo("forwardCommandOnReceive for device {} (type={}): rc={}", device.convertToString(), device_type, forwardOnReceive);
+		if(forwardOnReceive == OK) {
+			devices.at(device).enableImmediateCommandForwarding();
+			log::logInfo("Immediate command forwarding ENABLED for device {}", device.convertToString());
+		}
+
 		force_aggregation_on_device(device);
 		return 1;
 	}
@@ -119,6 +132,7 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 
 int StatusAggregator::get_aggregated_status(Buffer &generated_status,
 											const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	if(is_device_valid(device) == NOT_OK) {
 		log::logError("Trying to get aggregated status from unregistered device");
 		return DEVICE_NOT_REGISTERED;
@@ -135,6 +149,7 @@ int StatusAggregator::get_aggregated_status(Buffer &generated_status,
 }
 
 int StatusAggregator::get_unique_devices(std::list<structures::DeviceIdentification> &unique_devices_list) {
+	std::lock_guard lock(devicesMutex_);
 	const auto devicesSize = devices.size();
 	if (devicesSize == 0) {
 		return 0;
@@ -148,6 +163,7 @@ int StatusAggregator::get_unique_devices(std::list<structures::DeviceIdentificat
 }
 
 int StatusAggregator::force_aggregation_on_device(const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	if(is_device_valid(device) == NOT_OK) {
 		log::logError("Trying to force aggregation on unregistered device: {}", device.convertToString());
 		return DEVICE_NOT_REGISTERED;
@@ -160,6 +176,7 @@ int StatusAggregator::force_aggregation_on_device(const structures::DeviceIdenti
 }
 
 int StatusAggregator::is_device_valid(const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	if(is_device_type_supported(device.getDeviceType()) == OK &&
 	   devices.contains(device)) {
 		return OK;
@@ -170,6 +187,7 @@ int StatusAggregator::is_device_valid(const structures::DeviceIdentification& de
 int StatusAggregator::get_module_number() { return module_->getModuleNumber(); }
 
 int StatusAggregator::update_command(const Buffer& command, const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
 	const auto &device_type = device.getDeviceType();
 	if(is_device_type_supported(device_type) == NOT_OK) {
 		log::logError("Device type {} is not supported", device_type);
@@ -189,11 +207,18 @@ int StatusAggregator::update_command(const Buffer& command, const structures::De
 	if (devices.at(device).addExternalCommand(command) == NOT_OK) {
 		log::logError("External command queue is full for device: {} deleting oldest command", device.convertToString());
 	}
+
+	const bool forwarding = devices.at(device).isForwardCommandImmediately();
+	log::logDebug("update_command for device {}: isForwardCommandImmediately={}", device.convertToString(), forwarding);
+	if(forwarding) {
+		return FORWARD_IMMEDIATELY;
+	}
 	return OK;
 }
 
 int StatusAggregator::get_command(const Buffer& status, const structures::DeviceIdentification& device,
 								  Buffer& command) {
+	std::lock_guard lock(devicesMutex_);
 	const auto &device_type = device.getDeviceType();
 	if(is_device_type_supported(device_type) == NOT_OK) {
 		log::logError("Device type {} is not supported", device_type);
@@ -210,6 +235,16 @@ int StatusAggregator::get_command(const Buffer& status, const structures::Device
 	return OK;
 }
 
+int StatusAggregator::get_command_for_forwarding(const structures::DeviceIdentification &device, Buffer &command) {
+	std::lock_guard lock(devicesMutex_);
+	if(is_device_valid(device) == NOT_OK) {
+		log::logError("Trying to get forwarding command for unregistered device: {}", device.convertToString());
+		return DEVICE_NOT_REGISTERED;
+	}
+	const auto &cachedStatus = devices.at(device).getStatus();
+	return get_command(cachedStatus, device, command);
+}
+
 int StatusAggregator::is_device_type_supported(unsigned int device_type) {
 	return module_->isDeviceTypeSupported(device_type);
 }
@@ -223,6 +258,7 @@ bool StatusAggregator::getTimeoutedMessageReady() const {
 }
 
 int StatusAggregator::getDeviceTimeoutCount(const structures::DeviceIdentification &device) const {
+	std::lock_guard lock(devicesMutex_);
 	if(const auto it = deviceTimeouts_.find(device); it != deviceTimeouts_.end()) {
 		return it->second;
 	}

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -221,7 +221,11 @@ int StatusAggregator::get_command(const Buffer& status, const structures::Device
 	}
 
 	auto &deviceState = devices.at(device);
-	if (module_->generateCommand(command, status, deviceState.getStatus(), deviceState.getCommand(), device_type) != OK) {
+	auto currentCommand = deviceState.consumeCommand();
+	if (!currentCommand.has_value()) {
+		return NO_MESSAGE_AVAILABLE;
+	}
+	if (module_->generateCommand(command, status, deviceState.getStatus(), *currentCommand, device_type) != OK) {
 		log::logError("Error occurred while generating command for device: {}", device.convertToString());
 		return COMMAND_INVALID;
 	}

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -9,9 +9,8 @@ namespace bringauto::modules {
 
 using log = settings::Logger;
 
-int StatusAggregator::clear_device(const structures::DeviceIdentification &device) {
-	std::lock_guard lock(devicesMutex_);
-	if(is_device_valid(device) == NOT_OK) {
+int StatusAggregator::clearDeviceUnlocked(const structures::DeviceIdentification &device) {
+	if(isDeviceValidUnlocked(device) == NOT_OK) {
 		return DEVICE_NOT_REGISTERED;
 	}
 	auto &deviceState = devices.at(device);
@@ -20,6 +19,11 @@ int StatusAggregator::clear_device(const structures::DeviceIdentification &devic
 		aggregatedMessages.pop();
 	}
 	return OK;
+}
+
+int StatusAggregator::clear_device(const structures::DeviceIdentification &device) {
+	std::lock_guard lock(devicesMutex_);
+	return clearDeviceUnlocked(device);
 }
 
 Buffer
@@ -62,17 +66,17 @@ int StatusAggregator::destroy_status_aggregator() {
 int StatusAggregator::clear_all_devices() {
 	std::lock_guard lock(devicesMutex_);
 	for(auto &[key, device]: devices) {
-		clear_device(key);
+		clearDeviceUnlocked(key);
 	}
 	return OK;
 }
 
 int StatusAggregator::remove_device(const structures::DeviceIdentification& device) {
 	std::lock_guard lock(devicesMutex_);
-	if(is_device_valid(device) == NOT_OK) {
+	if(isDeviceValidUnlocked(device) == NOT_OK) {
 		return DEVICE_NOT_REGISTERED;
 	}
-	clear_device(device);
+	clearDeviceUnlocked(device);
 
 	boost::asio::post(context_->ioContext, [this, device]() {
 		std::lock_guard postLock(devicesMutex_);
@@ -104,8 +108,7 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 					deviceTimeouts_[deviceId]++;
 					return force_aggregation_on_device(deviceId);
 		};
-		devices.emplace(
-				device, structures::StatusAggregatorDeviceState(context_, timeouted_force_aggregation, device, commandBuffer, status));
+		devices.try_emplace(device, context_, timeouted_force_aggregation, device, commandBuffer, status);
 
 		const int forwardOnReceive = module_->forwardCommandOnReceive(device_type);
 		log::logInfo("forwardCommandOnReceive for device {} (type={}): rc={}", device.convertToString(), device_type, forwardOnReceive);
@@ -114,7 +117,7 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 			log::logInfo("Immediate command forwarding ENABLED for device {}", device.convertToString());
 		}
 
-		force_aggregation_on_device(device);
+		forceAggregationOnDeviceUnlocked(device);
 		return 1;
 	}
 
@@ -133,7 +136,7 @@ int StatusAggregator::add_status_to_aggregator(const Buffer& status,
 int StatusAggregator::get_aggregated_status(Buffer &generated_status,
 											const structures::DeviceIdentification& device) {
 	std::lock_guard lock(devicesMutex_);
-	if(is_device_valid(device) == NOT_OK) {
+	if(isDeviceValidUnlocked(device) == NOT_OK) {
 		log::logError("Trying to get aggregated status from unregistered device");
 		return DEVICE_NOT_REGISTERED;
 	}
@@ -162,9 +165,8 @@ int StatusAggregator::get_unique_devices(std::list<structures::DeviceIdentificat
 	return devicesSize;
 }
 
-int StatusAggregator::force_aggregation_on_device(const structures::DeviceIdentification& device) {
-	std::lock_guard lock(devicesMutex_);
-	if(is_device_valid(device) == NOT_OK) {
+int StatusAggregator::forceAggregationOnDeviceUnlocked(const structures::DeviceIdentification& device) {
+	if(isDeviceValidUnlocked(device) == NOT_OK) {
 		log::logError("Trying to force aggregation on unregistered device: {}", device.convertToString());
 		return DEVICE_NOT_REGISTERED;
 	}
@@ -175,13 +177,22 @@ int StatusAggregator::force_aggregation_on_device(const structures::DeviceIdenti
 	return aggregatedMessages.size();
 }
 
-int StatusAggregator::is_device_valid(const structures::DeviceIdentification& device) {
+int StatusAggregator::force_aggregation_on_device(const structures::DeviceIdentification& device) {
 	std::lock_guard lock(devicesMutex_);
+	return forceAggregationOnDeviceUnlocked(device);
+}
+
+int StatusAggregator::isDeviceValidUnlocked(const structures::DeviceIdentification& device) {
 	if(is_device_type_supported(device.getDeviceType()) == OK &&
 	   devices.contains(device)) {
 		return OK;
 	}
 	return NOT_OK;
+}
+
+int StatusAggregator::is_device_valid(const structures::DeviceIdentification& device) {
+	std::lock_guard lock(devicesMutex_);
+	return isDeviceValidUnlocked(device);
 }
 
 int StatusAggregator::get_module_number() { return module_->getModuleNumber(); }
@@ -211,9 +222,8 @@ int StatusAggregator::update_command(const Buffer& command, const structures::De
 	return OK;
 }
 
-int StatusAggregator::get_command(const Buffer& status, const structures::DeviceIdentification& device,
-								  Buffer& command) {
-	std::lock_guard lock(devicesMutex_);
+int StatusAggregator::getCommandUnlocked(const Buffer& status, const structures::DeviceIdentification& device,
+										  Buffer& command) {
 	const auto &device_type = device.getDeviceType();
 	if(is_device_type_supported(device_type) == NOT_OK) {
 		log::logError("Device type {} is not supported", device_type);
@@ -234,14 +244,20 @@ int StatusAggregator::get_command(const Buffer& status, const structures::Device
 	return OK;
 }
 
+int StatusAggregator::get_command(const Buffer& status, const structures::DeviceIdentification& device,
+								  Buffer& command) {
+	std::lock_guard lock(devicesMutex_);
+	return getCommandUnlocked(status, device, command);
+}
+
 int StatusAggregator::get_command_for_forwarding(const structures::DeviceIdentification &device, Buffer &command) {
 	std::lock_guard lock(devicesMutex_);
-	if(is_device_valid(device) == NOT_OK) {
+	if(isDeviceValidUnlocked(device) == NOT_OK) {
 		log::logError("Trying to get forwarding command for unregistered device: {}", device.convertToString());
 		return DEVICE_NOT_REGISTERED;
 	}
 	const auto &cachedStatus = devices.at(device).getStatus();
-	return get_command(cachedStatus, device, command);
+	return getCommandUnlocked(cachedStatus, device, command);
 }
 
 int StatusAggregator::is_device_type_supported(unsigned int device_type) {

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -208,11 +208,6 @@ int StatusAggregator::update_command(const Buffer& command, const structures::De
 		log::logError("External command queue is full for device: {} deleting oldest command", device.convertToString());
 	}
 
-	const bool forwarding = devices.at(device).isForwardCommandImmediately();
-	log::logDebug("update_command for device {}: isForwardCommandImmediately={}", device.convertToString(), forwarding);
-	if(forwarding) {
-		return FORWARD_IMMEDIATELY;
-	}
 	return OK;
 }
 

--- a/source/bringauto/structures/InternalClientMessage.cpp
+++ b/source/bringauto/structures/InternalClientMessage.cpp
@@ -12,8 +12,16 @@ bool InternalClientMessage::disconnected() const {
 	return disconnect_;
 }
 
+bool InternalClientMessage::isCommandForward() const noexcept {
+	return commandForward_;
+}
+
 const DeviceIdentification &InternalClientMessage::getDeviceId() const {
 	return deviceId_;
+}
+
+InternalClientMessage InternalClientMessage::makeCommandForward(const DeviceIdentification &deviceId) {
+	return InternalClientMessage { deviceId, true };
 }
 
 }

--- a/source/bringauto/structures/StatusAggregatorDeviceState.cpp
+++ b/source/bringauto/structures/StatusAggregatorDeviceState.cpp
@@ -33,11 +33,15 @@ void StatusAggregatorDeviceState::setDefaultCommand(const modules::Buffer &comma
 	defaultCommand_ = commandBuffer;
 }
 
-const modules::Buffer &StatusAggregatorDeviceState::getCommand() {
+std::optional<modules::Buffer> StatusAggregatorDeviceState::consumeCommand() {
 	std::lock_guard lock { *externalCommandMutex_ };
 	if (!externalCommandQueue_.empty()) {
 		defaultCommand_ = externalCommandQueue_.front();
 		externalCommandQueue_.pop();
+		return defaultCommand_;
+	}
+	if (forwardCommandImmediately_) {
+		return std::nullopt;
 	}
 	return defaultCommand_;
 }

--- a/source/bringauto/structures/StatusAggregatorDeviceState.cpp
+++ b/source/bringauto/structures/StatusAggregatorDeviceState.cpp
@@ -34,6 +34,7 @@ void StatusAggregatorDeviceState::setDefaultCommand(const modules::Buffer &comma
 }
 
 const modules::Buffer &StatusAggregatorDeviceState::getCommand() {
+	std::lock_guard lock { *externalCommandMutex_ };
 	if (!externalCommandQueue_.empty()) {
 		defaultCommand_ = externalCommandQueue_.front();
 		externalCommandQueue_.pop();
@@ -46,6 +47,7 @@ std::queue<struct modules::Buffer> &StatusAggregatorDeviceState::aggregatedMessa
 }
 
 int StatusAggregatorDeviceState::addExternalCommand(const modules::Buffer &commandBuffer) {
+	std::lock_guard lock { *externalCommandMutex_ };
 	externalCommandQueue_.push(commandBuffer);
 	if (externalCommandQueue_.size() > settings::max_external_commands) {
 		externalCommandQueue_.pop();

--- a/source/bringauto/structures/StatusAggregatorDeviceState.cpp
+++ b/source/bringauto/structures/StatusAggregatorDeviceState.cpp
@@ -34,7 +34,7 @@ void StatusAggregatorDeviceState::setDefaultCommand(const modules::Buffer &comma
 }
 
 std::optional<modules::Buffer> StatusAggregatorDeviceState::consumeCommand() {
-	std::lock_guard lock { *externalCommandMutex_ };
+	std::lock_guard lock { externalCommandMutex_ };
 	if (!externalCommandQueue_.empty()) {
 		defaultCommand_ = externalCommandQueue_.front();
 		externalCommandQueue_.pop();
@@ -51,7 +51,7 @@ std::queue<struct modules::Buffer> &StatusAggregatorDeviceState::aggregatedMessa
 }
 
 int StatusAggregatorDeviceState::addExternalCommand(const modules::Buffer &commandBuffer) {
-	std::lock_guard lock { *externalCommandMutex_ };
+	std::lock_guard lock { externalCommandMutex_ };
 	externalCommandQueue_.push(commandBuffer);
 	if (externalCommandQueue_.size() > settings::max_external_commands) {
 		externalCommandQueue_.pop();

--- a/source/bringauto/structures/StatusAggregatorDeviceState.cpp
+++ b/source/bringauto/structures/StatusAggregatorDeviceState.cpp
@@ -56,4 +56,12 @@ int StatusAggregatorDeviceState::addExternalCommand(const modules::Buffer &comma
 	return OK;
 }
 
+void StatusAggregatorDeviceState::enableImmediateCommandForwarding() noexcept {
+	forwardCommandImmediately_ = true;
+}
+
+bool StatusAggregatorDeviceState::isForwardCommandImmediately() const noexcept {
+	return forwardCommandImmediately_;
+}
+
 }


### PR DESCRIPTION
## Summary

  Adds an optional `forward_command_on_receive(device_type)` API that modules can
  export
  to opt in to immediate command dispatch — bypassing the up-to-40 ms wait for the
  next
  device status. Required for teleoperation, where the rest of the pipeline is already
  event-driven.

  ## How it works

  - **Module opt-in** — modules export the optional C symbol
  `forward_command_on_receive`.
    Absent symbol or `NOT_OK` return = existing pull behaviour. `OK` = push mode.
  - **Registration** — `StatusAggregator::add_status_to_aggregator` calls the function
  once
    and caches the result in
  `StatusAggregatorDeviceState::forwardCommandImmediately_`.
  - **ExternalClient** — on receiving a command for a push-mode device, pushes a
    `InternalClientMessage::makeCommandForward(deviceId)` event into
  `commandForwardingQueue_`
    (a new queue shared with ModuleHandler).
  - **ModuleHandler** — runs a dedicated `handleCommandForwards()` thread that drains
    `commandForwardingQueue_` and calls `get_command_for_forwarding()` (cached status
  as input),
    then pushes the result straight to `toInternalQueue_`.
  - **Push-only pull path** — `consumeCommand()` (renamed from `getCommand()`) returns
    `std::nullopt` when a push-only device has no pending command. `handleStatus`
  sends an
    empty `DeviceCommand` to satisfy the InternalProtocol 250 ms response requirement;
  the
    bridge detects empty `commanddata` and does not forward it to the vehicle.

  ## Thread safety

  - `StatusAggregator::devicesMutex_` (`recursive_mutex`) serialises all access to
  `devices`
    and `deviceTimeouts_` between the ModuleHandler main thread, the new forward
  thread, and
    ExternalClient.
  - `StatusAggregatorDeviceState::externalCommandMutex_` protects
  `externalCommandQueue_`
    against concurrent `addExternalCommand` / `consumeCommand` calls.

  ## Also included

  - **Fix** `InternalServer::processBufferData` bounds check: `bufferOffset +
  bytesTransferred
    > buffer.size()` (was `bytesTransferred < bufferOffset`); corrects recursive
  offset
    propagation on multi-message buffers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added command forwarding capability for faster command dispatch with compatible modules
* Added QUIC protocol support for external client connections

**Bug Fixes**
* Improved connection initialization handling to stabilize device status aggregation during extended connection attempts
* Fixed buffer size validation in connection data processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->