### PR TITLE
bump fleet-protocol-interface to v2.1.0

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,7 +1,7 @@
 SET(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
 
 BA_PACKAGE_LIBRARY(protobuf                 v4.21.12)
-BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.0.0 NO_DEBUG ON)
+BA_PACKAGE_LIBRARY(fleet-protocol-interface v2.1.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(nlohmann-json            v3.12.0 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(cxxopts                  v3.3.1 NO_DEBUG ON)
 BA_PACKAGE_LIBRARY(boost                    v1.86.0)


### PR DESCRIPTION
The pinned `fleet-protocol-interface v2.0.0` package was removed from the gitea package repository, breaking the CI dependency download during CMake configure (build #843). Only `v2.1.0` is now available.

Re-checked all other dependencies in `cmake/Dependencies.cmake` against gitea — all match their pinned versions; this is the only one that changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `fleet-protocol-interface` dependency to v2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->