### PR TITLE
Reduce shared_ptr usage: value/reference semantics and RAII teardown

### DIFF
--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -77,7 +77,7 @@ private:
 	 *
 	 * @param deviceCommand new command which replaces the old one
 	 */
-	void handleCommand(const InternalProtocol::DeviceCommand &deviceCommand);
+	void handleCommand(const InternalProtocol::DeviceCommand &deviceCommand) const;
 
 	/**
 	 * @brief Send aggregated status message to the external server

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -24,8 +24,10 @@ public:
 
 	ExternalClient(structures::GlobalContext &context,
 				   structures::ModuleLibrary &moduleLibrary,
-				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
+				   structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue,
 				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue);
+
+	~ExternalClient();
 
 	/**
 	 * @brief Initialize connections, error aggregators
@@ -96,14 +98,14 @@ private:
 	std::unordered_map<unsigned int, std::reference_wrapper<connection::ExternalConnection>> externalConnectionMap_ {};
 	/// List of external connections, each device can have its own connection or multiple devices can share one connection
 	std::list<connection::ExternalConnection> externalConnectionsList_ {};
-	/// Queue for messages from module handler to external client to be sent to external server
-	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> toExternalQueue_;
+	/// Queue for  messages from module handler to external client to be sent to external server
+	structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue_;
 	/// Queue for device commands received by external client to module handler
-	std::shared_ptr<structures::AtomicQueue<InternalProtocol::DeviceCommand>> fromExternalQueue_ {};
+	structures::AtomicQueue<InternalProtocol::DeviceCommand> fromExternalQueue_;
 	/// Queue shared with ModuleHandler; used to push command-forward events for immediate dispatch
 	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
 
-	std::shared_ptr<structures::AtomicQueue<structures::ReconnectQueueItem>> reconnectQueue_ {};
+	structures::AtomicQueue<structures::ReconnectQueueItem> reconnectQueue_;
 
 	std::jthread fromExternalClientThread_ {};
 

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -22,7 +22,7 @@ namespace bringauto::external_client {
 class ExternalClient {
 public:
 
-	ExternalClient(const std::shared_ptr<structures::GlobalContext> &context,
+	ExternalClient(structures::GlobalContext &context,
 				   structures::ModuleLibrary &moduleLibrary,
 				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
 				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue);
@@ -107,7 +107,7 @@ private:
 
 	std::jthread fromExternalClientThread_ {};
 
-	std::shared_ptr<structures::GlobalContext> context_;
+	structures::GlobalContext& context_;
 
 	structures::ModuleLibrary &moduleLibrary_;
 

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -34,11 +34,6 @@ public:
 	 */
 	void run();
 
-	/**
-	 * @brief Stops connections and joins thread for command handling
-	 */
-	void destroy();
-
 private:
 
 	/**

--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -25,7 +25,7 @@ public:
 	ExternalClient(structures::GlobalContext &context,
 				   structures::ModuleLibrary &moduleLibrary,
 				   structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue,
-				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue);
+				   structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue);
 
 	~ExternalClient();
 
@@ -98,7 +98,7 @@ private:
 	/// Queue for device commands received by external client to module handler
 	structures::AtomicQueue<InternalProtocol::DeviceCommand> fromExternalQueue_;
 	/// Queue shared with ModuleHandler; used to push command-forward events for immediate dispatch
-	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
+	structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue_;
 
 	structures::AtomicQueue<structures::ReconnectQueueItem> reconnectQueue_;
 

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -27,8 +27,8 @@ public:
 	ExternalConnection(structures::GlobalContext &context,
 					   structures::ModuleLibrary &moduleLibrary,
 					   const structures::ExternalConnectionSettings &settings,
-					   const std::shared_ptr <structures::AtomicQueue<InternalProtocol::DeviceCommand>> &commandQueue,
-					   const std::shared_ptr <structures::AtomicQueue<structures::ReconnectQueueItem>>& reconnectQueue);
+					   structures::AtomicQueue<InternalProtocol::DeviceCommand> &commandQueue,
+					   structures::AtomicQueue<structures::ReconnectQueueItem>& reconnectQueue);
 
 	/**
 	 * @brief Initialize the external connection
@@ -190,10 +190,9 @@ private:
 	/// @brief Map of error aggregators, key is module number
 	std::unordered_map<unsigned int, ErrorAggregator> errorAggregators_ {};
 	/// Queue of commands received from external server, commands are processed by aggregator
-	std::shared_ptr <structures::AtomicQueue<InternalProtocol::DeviceCommand>> commandQueue_ {};
+	structures::AtomicQueue<InternalProtocol::DeviceCommand>& commandQueue_;
 
-	std::shared_ptr <structures::AtomicQueue<structures::ReconnectQueueItem>>
-	reconnectQueue_ {};
+	structures::AtomicQueue<structures::ReconnectQueueItem>& reconnectQueue_;
 };
 
 }

--- a/include/bringauto/external_client/connection/ExternalConnection.hpp
+++ b/include/bringauto/external_client/connection/ExternalConnection.hpp
@@ -24,7 +24,7 @@ namespace bringauto::external_client::connection {
  */
 class ExternalConnection {
 public:
-	ExternalConnection(const std::shared_ptr <structures::GlobalContext> &context,
+	ExternalConnection(structures::GlobalContext &context,
 					   structures::ModuleLibrary &moduleLibrary,
 					   const structures::ExternalConnectionSettings &settings,
 					   const std::shared_ptr <structures::AtomicQueue<InternalProtocol::DeviceCommand>> &commandQueue,
@@ -178,7 +178,7 @@ private:
 	/// State of the external connection - thread safe
 	std::atomic <ConnectionState> state_ { ConnectionState::NOT_INITIALIZED };
 
-	std::shared_ptr <structures::GlobalContext> context_ {};
+	structures::GlobalContext& context_;
 
 	structures::ModuleLibrary &moduleLibrary_;
 

--- a/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/DummyCommunication.hpp
@@ -30,7 +30,7 @@ public:
 
 	bool sendMessage(ExternalProtocol::ExternalClient *message) override;
 
-	std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
+	std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
 
 	void closeConnection() override;
 

--- a/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
+++ b/include/bringauto/external_client/connection/communication/ICommunicationChannel.hpp
@@ -37,9 +37,9 @@ public:
 	/**
 	 * @brief Receive message
 	 *
-	 * @return std::shared_ptr<ExternalProtocol::ExternalServer>
+	 * @return std::unique_ptr<ExternalProtocol::ExternalServer>
 	 */
-	virtual std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() = 0;
+	virtual std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() = 0;
 
 	/**
 	 * @brief Stop and destroy connection

--- a/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/MqttCommunication.hpp
@@ -24,7 +24,7 @@ public:
 
 	bool sendMessage(ExternalProtocol::ExternalClient *message) override;
 
-	std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
+	std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
 
 	void closeConnection() override;
 

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -67,7 +67,7 @@ namespace bringauto::external_client::connection::communication {
 		 * @return A shared pointer to the received ExternalServer message,
 		 *         or nullptr if no message is available or the connection is not active.
 		 */
-		std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
+		std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
 
 		/**
 		 * @brief Initiates a graceful shutdown of the QUIC connection.

--- a/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
+++ b/include/bringauto/external_client/connection/communication/QuicCommunication.hpp
@@ -64,7 +64,7 @@ namespace bringauto::external_client::connection::communication {
 		 * Otherwise, it retrieves and removes the next message from the inbound
 		 * queue and returns it.
 		 *
-		 * @return A shared pointer to the received ExternalServer message,
+		 * @return A unique pointer to the received ExternalServer message,
 		 *         or nullptr if no message is available or the connection is not active.
 		 */
 		std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
@@ -130,7 +130,7 @@ namespace bringauto::external_client::connection::communication {
 		/// @name Inbound (peer → this)
 		/// @{
 		/// Queue of incoming messages received from the peer
-		std::queue<std::shared_ptr<ExternalProtocol::ExternalServer> > inboundQueue_;
+		std::queue<std::unique_ptr<ExternalProtocol::ExternalServer> > inboundQueue_;
 		/// Mutex protecting access to the inbound message queue
 		std::mutex inboundMutex_;
 		/// Condition variable for signaling inbound message availability
@@ -251,7 +251,7 @@ namespace bringauto::external_client::connection::communication {
 		 *
 		 * @param msg Decoded message received from the peer.
 		 */
-		void onMessageDecoded(std::shared_ptr<ExternalProtocol::ExternalServer> msg);
+		void onMessageDecoded(std::unique_ptr<ExternalProtocol::ExternalServer> msg);
 
 		/**
 		 * @brief Sends a message to the peer using a QUIC stream.

--- a/include/bringauto/external_client/connection/messages/SentMessagesHandler.hpp
+++ b/include/bringauto/external_client/connection/messages/SentMessagesHandler.hpp
@@ -12,7 +12,7 @@ namespace bringauto::external_client::connection::messages {
 
 class SentMessagesHandler {
 public:
-	explicit SentMessagesHandler(const std::shared_ptr <structures::GlobalContext> &context,
+	explicit SentMessagesHandler(structures::GlobalContext &context,
 								 const std::function<void()> &endConnectionFunc);
 
 	/**
@@ -100,7 +100,7 @@ private:
 	/// Vector of connected devices, the value is device id - @see ProtobufUtils::getId()
 	std::vector <structures::DeviceIdentification> connectedDevices_ {};
 	/// Global context of module gateway
-	std::shared_ptr <structures::GlobalContext> context_ {};
+	structures::GlobalContext& context_;
 	/// Callback called by timer when status does not get response, registered by constructor
 	std::function<void()> endConnectionFunc_ {};
 	/// Returns true if status response was already handled. Used in NotAckedStatus

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -37,7 +37,7 @@ public:
 			: context_ { context }, acceptor_(context.ioContext), fromInternalQueue_ { fromInternalQueue },
 			  toInternalQueue_ { toInternalQueue } {}
 
-	~InternalServer() = default;
+	~InternalServer();
 
 	/**
 	 * Starts the server.
@@ -45,15 +45,6 @@ public:
 	 * - Starts Thread that listens to data coming from ModuleHandler
 	 */
 	void run();
-
-	/**
-	 * Stop the server.
-	 * - Stops Acceptor.
-	 * - Notifies all running threads to end.
-	 * Must be called at the end of the Server instance lifetime.
-	 * After the stop() the start() can be called to reinitialized the Server instance.
-	 */
-	void destroy();
 
 private:
 	/**

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -32,8 +32,8 @@ public:
 	 * @param toInternalQueue queue for sending data from Module Handler to Server
 	 */
 	InternalServer(structures::GlobalContext &context,
-				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &fromInternalQueue,
-				   const std::shared_ptr<structures::AtomicQueue<structures::ModuleHandlerMessage>> &toInternalQueue)
+				   structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue,
+				   structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue)
 			: context_ { context }, acceptor_(context.ioContext), fromInternalQueue_ { fromInternalQueue },
 			  toInternalQueue_ { toInternalQueue } {}
 
@@ -201,9 +201,9 @@ private:
 	structures::GlobalContext& context_;
 	boost::asio::ip::tcp::acceptor acceptor_;
 	/// Queue for messages from Module Handler to Internal Client
-	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> fromInternalQueue_ {};
+	structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue_;
 	/// Queue for messages from Internal Client to Module Handler
-	std::shared_ptr<structures::AtomicQueue<structures::ModuleHandlerMessage>> toInternalQueue_ {};
+	structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue_;
 
 	std::mutex serverMutex_ {};
 	/// Vector of all active connections of devices

--- a/include/bringauto/internal_server/InternalServer.hpp
+++ b/include/bringauto/internal_server/InternalServer.hpp
@@ -31,10 +31,10 @@ public:
 	 * @param fromInternalQueue queue for sending data from Server to Module Handler
 	 * @param toInternalQueue queue for sending data from Module Handler to Server
 	 */
-	InternalServer(const std::shared_ptr<structures::GlobalContext> &context,
+	InternalServer(structures::GlobalContext &context,
 				   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &fromInternalQueue,
 				   const std::shared_ptr<structures::AtomicQueue<structures::ModuleHandlerMessage>> &toInternalQueue)
-			: context_ { context }, acceptor_(context->ioContext), fromInternalQueue_ { fromInternalQueue },
+			: context_ { context }, acceptor_(context.ioContext), fromInternalQueue_ { fromInternalQueue },
 			  toInternalQueue_ { toInternalQueue } {}
 
 	~InternalServer() = default;
@@ -198,7 +198,7 @@ private:
 	 */
 	std::shared_ptr<structures::Connection> findConnection(const structures::DeviceIdentification &deviceId);
 
-	std::shared_ptr<structures::GlobalContext> context_ {};
+	structures::GlobalContext& context_;
 	boost::asio::ip::tcp::acceptor acceptor_;
 	/// Queue for messages from Module Handler to Internal Client
 	std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> fromInternalQueue_ {};

--- a/include/bringauto/modules/ModuleHandler.hpp
+++ b/include/bringauto/modules/ModuleHandler.hpp
@@ -16,15 +16,12 @@ namespace bringauto::modules {
 class ModuleHandler {
 public:
 	ModuleHandler(
-			structures::GlobalContext &context,
-			structures::ModuleLibrary &moduleLibrary,
-			structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue,
-			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue,
-			structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue,
-			structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue)
-			: context_ { context }, moduleLibrary_ { moduleLibrary }, fromInternalQueue_ { fromInternalQueue },
-			  toInternalQueue_ { toInternalQueue }, commandForwardingQueue_ { commandForwardingQueue },
-			  toExternalQueue_ { toExternalQueue } {}
+		structures::GlobalContext& context,
+		structures::ModuleLibrary& moduleLibrary,
+		structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue,
+		structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue,
+		structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue,
+		structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue);
 
 	~ModuleHandler();
 
@@ -113,7 +110,7 @@ private:
 	/// Queue for incoming messages from internal server (connect/status/disconnect)
 	structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue_;
 	/// Queue for command-forward events from external client
-	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
+	structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue_;
 	/// Queue for outgoing messages to internal server to be forwarded to devices
 	structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue_;
 	/// Queue for outgoing messages to external server to be forwarded to external server

--- a/include/bringauto/modules/ModuleHandler.hpp
+++ b/include/bringauto/modules/ModuleHandler.hpp
@@ -18,13 +18,13 @@ public:
 	ModuleHandler(
 			structures::GlobalContext &context,
 			structures::ModuleLibrary &moduleLibrary,
-			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &fromInternalQueue,
+			structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue,
 			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue,
-			const std::shared_ptr <structures::AtomicQueue<structures::ModuleHandlerMessage>> &toInternalQueue,
-			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue)
-			: context_ { context }, moduleLibrary_ { moduleLibrary },
-			  fromInternalQueue_ { fromInternalQueue }, commandForwardingQueue_ { commandForwardingQueue },
-			  toInternalQueue_ { toInternalQueue }, toExternalQueue_ { toExternalQueue } {}
+			structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue,
+			structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue)
+			: context_ { context }, moduleLibrary_ { moduleLibrary }, fromInternalQueue_ { fromInternalQueue },
+			  toInternalQueue_ { toInternalQueue }, commandForwardingQueue_ { commandForwardingQueue },
+			  toExternalQueue_ { toExternalQueue } {}
 
 	/**
 	 * @brief Start Module handler
@@ -115,13 +115,13 @@ private:
 
 	structures::ModuleLibrary &moduleLibrary_;
 	/// Queue for incoming messages from internal server (connect/status/disconnect)
-	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> fromInternalQueue_ {};
+	structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue_;
 	/// Queue for command-forward events from external client
 	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> commandForwardingQueue_ {};
 	/// Queue for outgoing messages to internal server to be forwarded to devices
-	std::shared_ptr <structures::AtomicQueue<structures::ModuleHandlerMessage>> toInternalQueue_ {};
+	structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue_;
 	/// Queue for outgoing messages to external server to be forwarded to external server
-	std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> toExternalQueue_ {};
+	structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue_;
 };
 
 }

--- a/include/bringauto/modules/ModuleHandler.hpp
+++ b/include/bringauto/modules/ModuleHandler.hpp
@@ -26,6 +26,8 @@ public:
 			  toInternalQueue_ { toInternalQueue }, commandForwardingQueue_ { commandForwardingQueue },
 			  toExternalQueue_ { toExternalQueue } {}
 
+	~ModuleHandler();
+
 	/**
 	 * @brief Start Module handler
 	 *
@@ -33,12 +35,6 @@ public:
 	 *
 	 */
 	void run() const;
-
-	/**
-	 * @brief Stop Module handler and clean all initialized modules
-	 *
-	 */
-	void destroy() const;
 
 private:
 

--- a/include/bringauto/modules/ModuleHandler.hpp
+++ b/include/bringauto/modules/ModuleHandler.hpp
@@ -16,7 +16,7 @@ namespace bringauto::modules {
 class ModuleHandler {
 public:
 	ModuleHandler(
-			const std::shared_ptr <structures::GlobalContext> &context,
+			structures::GlobalContext &context,
 			structures::ModuleLibrary &moduleLibrary,
 			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &fromInternalQueue,
 			const std::shared_ptr <structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue,
@@ -111,7 +111,7 @@ private:
 	 */
 	void checkExternalQueueSize() const;
 
-	std::shared_ptr <structures::GlobalContext> context_ {};
+	structures::GlobalContext& context_;
 
 	structures::ModuleLibrary &moduleLibrary_;
 	/// Queue for incoming messages from internal server (connect/status/disconnect)

--- a/include/bringauto/modules/StatusAggregator.hpp
+++ b/include/bringauto/modules/StatusAggregator.hpp
@@ -20,12 +20,10 @@ namespace bringauto::modules {
 class StatusAggregator {
 public:
 
-	explicit StatusAggregator(const std::shared_ptr<structures::GlobalContext> &context,
+	explicit StatusAggregator(structures::GlobalContext &context,
 							  const std::shared_ptr<IModuleManagerLibraryHandler> &libraryHandler): context_ { context },
 																								   	module_ {
 																									libraryHandler } {};
-
-	StatusAggregator() = default;
 
 	/**
 	 * @short Status aggregator init.
@@ -230,7 +228,7 @@ private:
 	void aggregateSetSendStatus(structures::StatusAggregatorDeviceState &deviceState, const Buffer &status,
 								const unsigned int &device_type) const;
 
-	std::shared_ptr<structures::GlobalContext> context_ {};
+	structures::GlobalContext& context_;
 
 	const std::shared_ptr<IModuleManagerLibraryHandler> module_ {};
 

--- a/include/bringauto/settings/SettingsParser.hpp
+++ b/include/bringauto/settings/SettingsParser.hpp
@@ -28,9 +28,9 @@ public:
 
 	/**
 	 * @brief Can be used after calling parseSettings(...) to get settings
-	 * @return shared ptr to settings
+	 * @return settings
 	 */
-	std::shared_ptr<Settings> getSettings();
+	const Settings& getSettings();
 
 	/**
 	 * @brief Serializes settings to json
@@ -40,7 +40,7 @@ public:
 
 private:
 	cxxopts::ParseResult cmdArguments_ {};
-	std::shared_ptr<Settings> settings_ {};
+	Settings settings_ {};
 
 	void parseCmdArguments(int argc, char **argv);
 
@@ -50,12 +50,12 @@ private:
 
 	void fillSettings();
 
-	void fillLoggingSettings(const nlohmann::json &file) const;
+	void fillLoggingSettings(const nlohmann::json &file);
 
-	void fillInternalServerSettings(const nlohmann::json &file) const;
+	void fillInternalServerSettings(const nlohmann::json &file);
 
-	void fillModulePathsSettings(const nlohmann::json &file) const;
+	void fillModulePathsSettings(const nlohmann::json &file);
 
-	void fillExternalConnectionSettings(const nlohmann::json &file) const;
+	void fillExternalConnectionSettings(const nlohmann::json &file);
 };
 }

--- a/include/bringauto/structures/Connection.hpp
+++ b/include/bringauto/structures/Connection.hpp
@@ -5,6 +5,7 @@
 #include <boost/asio.hpp>
 
 #include <condition_variable>
+#include <optional>
 #include <string>
 
 
@@ -47,7 +48,7 @@ struct Connection {
 	/**
 	 * @brief identification of connected device
 	 */
-	std::shared_ptr <DeviceIdentification> deviceId {};
+	std::optional<DeviceIdentification> deviceId {};
 	/**
 	 * @brief Context for connection
 	 */

--- a/include/bringauto/structures/DeviceIdentification.hpp
+++ b/include/bringauto/structures/DeviceIdentification.hpp
@@ -23,13 +23,8 @@ public:
 	 */
 	explicit DeviceIdentification(const ::device_identification &device);
 
-	DeviceIdentification(const DeviceIdentification& device) {
-		module_ = device.module_;
-		deviceType_ = device.deviceType_;
-		priority_ = device.priority_;
-		deviceRole_ = device.deviceRole_;
-		deviceName_ = device.deviceName_;
-	}
+	DeviceIdentification(const DeviceIdentification&) = default;
+	DeviceIdentification& operator=(const DeviceIdentification&) = default;
 
 	DeviceIdentification() = default;
 

--- a/include/bringauto/structures/DeviceIdentification.hpp
+++ b/include/bringauto/structures/DeviceIdentification.hpp
@@ -63,7 +63,7 @@ public:
 	 * @param toCompare device used for comparison
 	 * @return true if all parameters outside of priority are equal
 	 */
-	[[nodiscard]] bool isSame(const std::shared_ptr <DeviceIdentification> &toCompare) const;
+	[[nodiscard]] bool isSame(const DeviceIdentification &toCompare) const;
 
 	/**
 	 * @brief Assigns values from device to this object

--- a/include/bringauto/structures/GlobalContext.hpp
+++ b/include/bringauto/structures/GlobalContext.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/asio.hpp>
 #include <bringauto/settings/Settings.hpp>
+#include <utility>
 
 
 
@@ -10,10 +11,8 @@ namespace bringauto::structures {
  * @brief Context structure which is shared across ModuleGateway project.
  */
 struct GlobalContext {
-
 	GlobalContext() = default;
-
-	explicit GlobalContext(const std::shared_ptr<settings::Settings> &settings_): settings(settings_) {}
+	explicit GlobalContext(settings::Settings settings_): settings(std::move(settings_)) {}
 
 	/**
 	 * @brief io_context shared across Module Gateway
@@ -23,6 +22,6 @@ struct GlobalContext {
 	/**
 	 * @brief settings used in the project
 	 */
-	std::shared_ptr<settings::Settings> settings {};
+	settings::Settings settings {};
 };
 }

--- a/include/bringauto/structures/ModuleLibrary.hpp
+++ b/include/bringauto/structures/ModuleLibrary.hpp
@@ -30,7 +30,7 @@ struct ModuleLibrary {
 	 *
 	 * @param context global context
 	 */
-	void initStatusAggregators(std::shared_ptr<GlobalContext> &context);
+	void initStatusAggregators(GlobalContext &context);
 	/// Map of module handlers, key is module id
 	std::unordered_map<int, std::shared_ptr<modules::IModuleManagerLibraryHandler>> moduleLibraryHandlers {};
 	/// Map of status aggregators, key is module id

--- a/include/bringauto/structures/StatusAggregatorDeviceState.hpp
+++ b/include/bringauto/structures/StatusAggregatorDeviceState.hpp
@@ -22,7 +22,7 @@ public:
 
 	StatusAggregatorDeviceState() = default;
 
-	StatusAggregatorDeviceState(std::shared_ptr<GlobalContext> &context,
+	StatusAggregatorDeviceState(GlobalContext &context,
 								std::function<int(const DeviceIdentification&)> fun,
 								const DeviceIdentification &deviceId,
 								const modules::Buffer& command, const modules::Buffer& status);

--- a/include/bringauto/structures/ThreadTimer.hpp
+++ b/include/bringauto/structures/ThreadTimer.hpp
@@ -28,9 +28,9 @@ public:
 	 * @param function Function which should be executed
 	 * @param deviceId DeviceIdentification
 	 */
-	explicit ThreadTimer(const std::shared_ptr<GlobalContext> &context,
+	explicit ThreadTimer(GlobalContext &context,
 						 const std::function<int(const DeviceIdentification&)> &function,
-						 const DeviceIdentification& deviceId): timer_ { context->ioContext },
+						 const DeviceIdentification& deviceId): timer_ { context.ioContext },
 																fun_ { function },
 																deviceId_ { deviceId } {}
 

--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		context->settings = settingsParser.getSettings();
-		initLogger(context->settings->loggingSettings);
+		initLogger(context->settings.loggingSettings);
 		baset::Logger::logInfo("Version: {}", MODULE_GATEWAY_VERSION);
 		baset::Logger::logInfo("Loaded config:\n{}", settingsParser.serializeToJson());
 	} catch(std::exception &e) {
@@ -61,10 +61,10 @@ int main(int argc, char **argv) {
 	bas::ModuleLibrary moduleLibrary {};
 
 	try {
-		if(context->settings->moduleBinaryPath.empty()) {
-			moduleLibrary.loadLibraries(context->settings->modulePaths);
+		if(context->settings.moduleBinaryPath.empty()) {
+			moduleLibrary.loadLibraries(context->settings.modulePaths);
 		} else {
-			moduleLibrary.loadLibraries(context->settings->modulePaths, context->settings->moduleBinaryPath);
+			moduleLibrary.loadLibraries(context->settings.modulePaths, context->settings.moduleBinaryPath);
 		}
 		moduleLibrary.initStatusAggregators(context);
 	} catch(std::exception &e) {

--- a/main.cpp
+++ b/main.cpp
@@ -77,10 +77,10 @@ int main(int argc, char **argv) {
 	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
 	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
-	auto toInternalQueue = std::make_shared<bas::AtomicQueue<bas::ModuleHandlerMessage >>();
-	auto fromInternalQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
+	bas::AtomicQueue<bas::ModuleHandlerMessage> toInternalQueue;
+	bas::AtomicQueue<bas::InternalClientMessage> fromInternalQueue;
 	auto commandForwardingQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
-	auto toExternalQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
+	bas::AtomicQueue<bas::InternalClientMessage> toExternalQueue;
 
 	bais::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
 	bringauto::modules::ModuleHandler moduleHandler { context, moduleLibrary, fromInternalQueue,

--- a/main.cpp
+++ b/main.cpp
@@ -103,10 +103,6 @@ int main(int argc, char **argv) {
 	externalClientThread.join();
 	moduleHandlerThread.join();
 
-	internalServer.destroy();
-	moduleHandler.destroy();
-	externalClient.destroy();
-
 	google::protobuf::ShutdownProtobufLibrary();
 
 	return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 
 	bas::AtomicQueue<bas::ModuleHandlerMessage> toInternalQueue;
 	bas::AtomicQueue<bas::InternalClientMessage> fromInternalQueue;
-	auto commandForwardingQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
+	bas::AtomicQueue<bas::InternalClientMessage> commandForwardingQueue;
 	bas::AtomicQueue<bas::InternalClientMessage> toExternalQueue;
 
 	bais::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };

--- a/main.cpp
+++ b/main.cpp
@@ -42,15 +42,15 @@ int main(int argc, char **argv) {
 	namespace bais = bringauto::internal_server;
 	namespace bas = bringauto::structures;
 	namespace baset = bringauto::settings;
-	auto context = std::make_shared<bas::GlobalContext>();
 
+	baset::Settings settings {};
 	try {
 		baset::SettingsParser settingsParser;
 		if(!settingsParser.parseSettings(argc, argv)) {
 			return 0;
 		}
-		context->settings = settingsParser.getSettings();
-		initLogger(context->settings.loggingSettings);
+		settings = settingsParser.getSettings();
+		initLogger(settings.loggingSettings);
 		baset::Logger::logInfo("Version: {}", MODULE_GATEWAY_VERSION);
 		baset::Logger::logInfo("Loaded config:\n{}", settingsParser.serializeToJson());
 	} catch(std::exception &e) {
@@ -58,13 +58,15 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
+	bas::GlobalContext context { std::move(settings) };
+
 	bas::ModuleLibrary moduleLibrary {};
 
 	try {
-		if(context->settings.moduleBinaryPath.empty()) {
-			moduleLibrary.loadLibraries(context->settings.modulePaths);
+		if(context.settings.moduleBinaryPath.empty()) {
+			moduleLibrary.loadLibraries(context.settings.modulePaths);
 		} else {
-			moduleLibrary.loadLibraries(context->settings.modulePaths, context->settings.moduleBinaryPath);
+			moduleLibrary.loadLibraries(context.settings.modulePaths, context.settings.moduleBinaryPath);
 		}
 		moduleLibrary.initStatusAggregators(context);
 	} catch(std::exception &e) {
@@ -72,8 +74,8 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	boost::asio::signal_set signals(context->ioContext, SIGINT, SIGTERM);
-	signals.async_wait([context](auto, auto) { context->ioContext.stop(); });
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
 	auto toInternalQueue = std::make_shared<bas::AtomicQueue<bas::ModuleHandlerMessage >>();
 	auto fromInternalQueue = std::make_shared<bas::AtomicQueue<bas::InternalClientMessage >>();
@@ -87,13 +89,13 @@ int main(int argc, char **argv) {
 
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.run(); });
 	std::jthread externalClientThread([&externalClient]() { externalClient.run(); });
-	std::jthread contextThread2([&context]() { context->ioContext.run(); });
-	std::jthread contextThread1([&context]() { context->ioContext.run(); });
+	std::jthread contextThread2([&context]() { context.ioContext.run(); });
+	std::jthread contextThread1([&context]() { context.ioContext.run(); });
 	try {
 		internalServer.run();
 	} catch(boost::system::system_error &e) {
 		baset::Logger::logError("Error during run {}", e.what());
-		context->ioContext.stop();
+		context.ioContext.stop();
 	}
 
 	contextThread2.join();

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -19,7 +19,7 @@ namespace bringauto::external_client {
 
 namespace ip = InternalProtocol;
 
-ExternalClient::ExternalClient(const std::shared_ptr<structures::GlobalContext> &context,
+ExternalClient::ExternalClient(structures::GlobalContext &context,
 							   structures::ModuleLibrary &moduleLibrary,
 							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
 							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue):
@@ -27,7 +27,7 @@ ExternalClient::ExternalClient(const std::shared_ptr<structures::GlobalContext> 
 		commandForwardingQueue_ { commandForwardingQueue },
 		context_ { context },
 		moduleLibrary_ { moduleLibrary },
-		timer_ { context->ioContext } {
+		timer_ { context.ioContext } {
 	fromExternalQueue_ = std::make_shared<structures::AtomicQueue<InternalProtocol::DeviceCommand >>();
 	reconnectQueue_ =
 			std::make_shared<structures::AtomicQueue<structures::ReconnectQueueItem >>();
@@ -35,7 +35,7 @@ ExternalClient::ExternalClient(const std::shared_ptr<structures::GlobalContext> 
 }
 
 void ExternalClient::handleCommands() {
-	while(not context_->ioContext.stopped()) {
+	while(not context_.ioContext.stopped()) {
 		if(fromExternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
@@ -98,7 +98,7 @@ void ExternalClient::run() {
 }
 
 void ExternalClient::initConnections() {
-	for(auto const &connectionSettings: context_->settings.externalConnectionSettingsList) {
+	for(auto const &connectionSettings: context_.settings.externalConnectionSettingsList) {
 		externalConnectionsList_.emplace_back(context_, moduleLibrary_, connectionSettings, fromExternalQueue_,
 											  reconnectQueue_);
 		auto &newConnection = externalConnectionsList_.back();
@@ -107,12 +107,12 @@ void ExternalClient::initConnections() {
 		switch(connectionSettings.protocolType) {
 			case structures::ProtocolType::MQTT:
 				communicationChannel = std::make_shared<connection::communication::MqttCommunication>(
-					connectionSettings, context_->settings.company, context_->settings.vehicleName
+					connectionSettings, context_.settings.company, context_.settings.vehicleName
 				);
 				break;
 			case structures::ProtocolType::QUIC:
 				communicationChannel = std::make_shared<connection::communication::QuicCommunication>(
-					connectionSettings, context_->settings.company, context_->settings.vehicleName
+					connectionSettings, context_.settings.company, context_.settings.vehicleName
 				);
 				break;
 			case structures::ProtocolType::DUMMY:
@@ -134,7 +134,7 @@ void ExternalClient::initConnections() {
 }
 
 void ExternalClient::handleAggregatedMessages() {
-	while(not context_->ioContext.stopped()) {
+	while(not context_.ioContext.stopped()) {
 		if(not reconnectQueue_->empty()) {
 			auto &reconnectItem = reconnectQueue_->front();
 			auto &connection = reconnectItem.connection_.get();
@@ -197,7 +197,7 @@ bool ExternalClient::sendStatus(const structures::InternalClientMessage &interna
 
 void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &connection,
                                               std::atomic<bool> &connectDone) {
-	while (!connectDone.load() && !context_->ioContext.stopped() &&
+	while (!connectDone.load() && !context_.ioContext.stopped() &&
 	       connection.getState() != connection::ConnectionState::CONNECTED) {
 		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
 			continue;
@@ -246,7 +246,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	auto connectedDevices = connection.getAllConnectedDevices();
 	auto forcedDevices = connection.forceAggregationOnAllDevices(connectedDevices);
 
-	while(not forcedDevices.empty() && not context_->ioContext.stopped()) {
+	while(not forcedDevices.empty() && not context_.ioContext.stopped()) {
 		if(toExternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
@@ -289,7 +289,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 
 	drainQueueDuringConnect(connection, connectDone);
 
-	if (context_->ioContext.stopped() && !connectDone.load()) {
+	if (context_.ioContext.stopped() && !connectDone.load()) {
 		// Interrupt initializeConnection() so the thread can finish promptly.
 		// closeConnection() fires SHUTDOWN_COMPLETE which notifies inboundCv_,
 		// waking any blocked receiveMessage() call.
@@ -297,7 +297,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	}
 	connectThread.join();
 
-	if(connectResult != 0 && !context_->ioContext.stopped()) {
+	if(connectResult != 0 && !context_.ioContext.stopped()) {
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -47,7 +47,8 @@ void ExternalClient::handleCommands() {
 	}
 }
 
-void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &deviceCommand) {
+void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &deviceCommand) const
+{
 	const auto &device = deviceCommand.device();
 	const auto &moduleNumber = device.module();
 	auto &statusAggregators = moduleLibrary_.statusAggregators;
@@ -97,7 +98,7 @@ void ExternalClient::run() {
 }
 
 void ExternalClient::initConnections() {
-	for(auto const &connectionSettings: context_->settings->externalConnectionSettingsList) {
+	for(auto const &connectionSettings: context_->settings.externalConnectionSettingsList) {
 		externalConnectionsList_.emplace_back(context_, moduleLibrary_, connectionSettings, fromExternalQueue_,
 											  reconnectQueue_);
 		auto &newConnection = externalConnectionsList_.back();
@@ -106,12 +107,12 @@ void ExternalClient::initConnections() {
 		switch(connectionSettings.protocolType) {
 			case structures::ProtocolType::MQTT:
 				communicationChannel = std::make_shared<connection::communication::MqttCommunication>(
-					connectionSettings, context_->settings->company, context_->settings->vehicleName
+					connectionSettings, context_->settings.company, context_->settings.vehicleName
 				);
 				break;
 			case structures::ProtocolType::QUIC:
 				communicationChannel = std::make_shared<connection::communication::QuicCommunication>(
-					connectionSettings, context_->settings->company, context_->settings->vehicleName
+					connectionSettings, context_->settings.company, context_->settings.vehicleName
 				);
 				break;
 			case structures::ProtocolType::DUMMY:

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -78,10 +78,6 @@ void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &device
 }
 
 ExternalClient::~ExternalClient() {
-	destroy();
-}
-
-void ExternalClient::destroy() {
 	for(auto &externalConnection: externalConnectionsList_) {
 		externalConnection.deinitializeConnection(true);
 	}

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -22,7 +22,7 @@ namespace ip = InternalProtocol;
 ExternalClient::ExternalClient(structures::GlobalContext &context,
 							   structures::ModuleLibrary &moduleLibrary,
 							   structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue,
-							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue):
+							   structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue):
 		toExternalQueue_ { toExternalQueue },
 		commandForwardingQueue_ { commandForwardingQueue },
 		context_ { context },
@@ -70,7 +70,7 @@ void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &device
 	if (ret == OK) {
 		if (moduleLibraryHandler->forwardCommandOnReceive(deviceId.getDeviceType()) == OK) {
 			settings::Logger::logInfo("Command for device {} was added to queue, forwarding immediately", device.devicename());
-			commandForwardingQueue_->pushAndNotify(structures::InternalClientMessage::makeCommandForward(deviceId));
+			commandForwardingQueue_.pushAndNotify(structures::InternalClientMessage::makeCommandForward(deviceId));
 		} else {
 			settings::Logger::logInfo("Command for device {} was added to queue", device.devicename());
 		}

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -21,29 +21,26 @@ namespace ip = InternalProtocol;
 
 ExternalClient::ExternalClient(structures::GlobalContext &context,
 							   structures::ModuleLibrary &moduleLibrary,
-							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &toExternalQueue,
+							   structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue,
 							   const std::shared_ptr<structures::AtomicQueue<structures::InternalClientMessage>> &commandForwardingQueue):
 		toExternalQueue_ { toExternalQueue },
 		commandForwardingQueue_ { commandForwardingQueue },
 		context_ { context },
 		moduleLibrary_ { moduleLibrary },
 		timer_ { context.ioContext } {
-	fromExternalQueue_ = std::make_shared<structures::AtomicQueue<InternalProtocol::DeviceCommand >>();
-	reconnectQueue_ =
-			std::make_shared<structures::AtomicQueue<structures::ReconnectQueueItem >>();
 	fromExternalClientThread_ = std::jthread(&ExternalClient::handleCommands, this);
 }
 
 void ExternalClient::handleCommands() {
 	while(not context_.ioContext.stopped()) {
-		if(fromExternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+		if(fromExternalQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
 		settings::Logger::logInfo("External client received command");
 
-		auto &message = fromExternalQueue_->front();
+		auto &message = fromExternalQueue_.front();
 		handleCommand(message);
-		fromExternalQueue_->pop();
+		fromExternalQueue_.pop();
 	}
 }
 
@@ -80,11 +77,19 @@ void ExternalClient::handleCommand(const InternalProtocol::DeviceCommand &device
 	}
 }
 
+ExternalClient::~ExternalClient() {
+	destroy();
+}
+
 void ExternalClient::destroy() {
 	for(auto &externalConnection: externalConnectionsList_) {
 		externalConnection.deinitializeConnection(true);
 	}
-	fromExternalClientThread_.join();
+	externalConnectionsList_.clear();
+	externalConnectionMap_.clear();
+	if(fromExternalClientThread_.joinable()) {
+		fromExternalClientThread_.join();
+	}
 	settings::Logger::logInfo("External client stopped");
 }
 
@@ -135,8 +140,8 @@ void ExternalClient::initConnections() {
 
 void ExternalClient::handleAggregatedMessages() {
 	while(not context_.ioContext.stopped()) {
-		if(not reconnectQueue_->empty()) {
-			auto &reconnectItem = reconnectQueue_->front();
+		if(not reconnectQueue_.empty()) {
+			auto &reconnectItem = reconnectQueue_.front();
 			auto &connection = reconnectItem.connection_.get();
 			connection.deinitializeConnection(false);
 			if(reconnectItem.reconnect) {
@@ -145,17 +150,17 @@ void ExternalClient::handleAggregatedMessages() {
 				settings::Logger::logInfo("External connection is disconnected from external server");
 				connection.setNotInitialized();
 			}
-			reconnectQueue_->pop();
+			reconnectQueue_.pop();
 		}
-		if(toExternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+		if(toExternalQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
 		settings::Logger::logInfo("External client received aggregated status, number of aggregated statuses in queue {}",
-					 toExternalQueue_->size());
-		auto message = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
+					 toExternalQueue_.size());
+		auto message = std::move(toExternalQueue_.front());
+		toExternalQueue_.pop();
 		if(not sendStatus(message)) {
-			reconnectQueue_->waitForValueWithTimeout(std::chrono::seconds(settings::immediate_disconnect_timeout));
+			reconnectQueue_.waitForValueWithTimeout(std::chrono::seconds(settings::immediate_disconnect_timeout));
 		}
 	}
 }
@@ -199,7 +204,7 @@ void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &con
                                               std::atomic<bool> &connectDone) {
 	while (!connectDone.load() && !context_.ioContext.stopped() &&
 	       connection.getState() != connection::ConnectionState::CONNECTED) {
-		if (toExternalQueue_->waitForValueWithTimeout(std::chrono::seconds(1))) {
+		if (toExternalQueue_.waitForValueWithTimeout(std::chrono::seconds(1))) {
 			continue;
 		}
 		// Re-check after unblocking, and do not consume disconnect messages —
@@ -207,11 +212,11 @@ void ExternalClient::drainQueueDuringConnect(connection::ExternalConnection &con
 		// fillErrorAggregator after clear_error_aggregator ran; the latter so the
 		// device is properly removed via deleteConnectedDevice()).
 		if (connectDone.load() || connection.getState() == connection::ConnectionState::CONNECTED ||
-		    toExternalQueue_->front().disconnected()) {
+		    toExternalQueue_.front().disconnected()) {
 			break;
 		}
-		const auto internalMessage = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
+		const auto internalMessage = std::move(toExternalQueue_.front());
+		toExternalQueue_.pop();
 		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
 		if (connection.isModuleSupported(deviceStatus.device().module())) {
 			connection.fillErrorAggregator(deviceStatus);
@@ -225,14 +230,14 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	settings::Logger::logInfo("Initializing new connection");
 	insideConnectSequence_ = true;
 
-	while(not toExternalQueue_->empty()) {
+	while(not toExternalQueue_.empty()) {
 		// Do not consume disconnect messages — they must reach handleAggregatedMessages
 		// so the device is properly removed via sendStatus(..., DISCONNECT).
-		if(toExternalQueue_->front().disconnected()) {
+		if(toExternalQueue_.front().disconnected()) {
 			break;
 		}
-		auto internalMessage = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
+		auto internalMessage = std::move(toExternalQueue_.front());
+		toExternalQueue_.pop();
 		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
 		if(connection.isModuleSupported(deviceStatus.device().module())) {
 			connection.fillErrorAggregator(deviceStatus);
@@ -247,11 +252,11 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 	auto forcedDevices = connection.forceAggregationOnAllDevices(connectedDevices);
 
 	while(not forcedDevices.empty() && not context_.ioContext.stopped()) {
-		if(toExternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+		if(toExternalQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
-		const auto internalMessage = std::move(toExternalQueue_->front());
-		toExternalQueue_->pop();
+		const auto internalMessage = std::move(toExternalQueue_.front());
+		toExternalQueue_.pop();
 
 		const auto &deviceStatus = internalMessage.getMessage().devicestatus();
 		const auto &device = deviceStatus.device();
@@ -261,7 +266,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 			if(it == forcedDevices.cend()) {
 				settings::Logger::logDebug("Cannot fill error aggregator for same device: {} {}", device.devicerole(),
 							  device.devicename());
-				toExternalQueue_->pushAndNotify(internalMessage);
+				toExternalQueue_.pushAndNotify(internalMessage);
 			} else {
 				settings::Logger::logDebug("Filling error aggregator of device: {} {}", device.devicerole(), device.devicename());
 				connection.fillErrorAggregator(deviceStatus);
@@ -301,7 +306,7 @@ void ExternalClient::startExternalConnectSequence(connection::ExternalConnection
 		settings::Logger::logDebug("Waiting for reconnect timer to expire");
 		timer_.expires_from_now(boost::posix_time::seconds(settings::reconnect_delay));
 		timer_.async_wait([this, &connection](const boost::system::error_code&) {
-			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(connection), true));
+			reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(connection), true));
 			settings::Logger::logDebug("Reconnect timer expired");
 		});
 	}

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -154,8 +154,8 @@ int ExternalConnection::connectMessageHandle(const std::vector<structures::Devic
 	generateSessionId();
 
 	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_,
-																				   context_->settings->company,
-																				   context_->settings->vehicleName,
+																				   context_->settings.company,
+																				   context_->settings.vehicleName,
 																				   devices);
 	if(not communicationChannel_->sendMessage(&connectMessage)){
 		log::logError("Communication client couldn't send any message");

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -12,7 +12,7 @@
 namespace bringauto::external_client::connection {
 using log = settings::Logger;
 
-ExternalConnection::ExternalConnection(const std::shared_ptr<structures::GlobalContext> &context,
+ExternalConnection::ExternalConnection(structures::GlobalContext &context,
 									   structures::ModuleLibrary &moduleLibrary,
 									   const structures::ExternalConnectionSettings &settings,
 									   const std::shared_ptr<structures::AtomicQueue<InternalProtocol::DeviceCommand>> &commandQueue,
@@ -23,7 +23,7 @@ ExternalConnection::ExternalConnection(const std::shared_ptr<structures::GlobalC
 		settings_ { settings },
 		commandQueue_ { commandQueue },
 		reconnectQueue_ { reconnectQueue } {
-	sentMessagesHandler_ = std::make_unique<messages::SentMessagesHandler>(context, [this]() {
+	sentMessagesHandler_ = std::make_unique<messages::SentMessagesHandler>(context_, [this]() {
 		reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 	});
 }
@@ -154,8 +154,8 @@ int ExternalConnection::connectMessageHandle(const std::vector<structures::Devic
 	generateSessionId();
 
 	auto connectMessage = common_utils::ProtobufUtils::createExternalClientConnect(sessionId_,
-																				   context_->settings.company,
-																				   context_->settings.vehicleName,
+																				   context_.settings.company,
+																				   context_.settings.vehicleName,
 																				   devices);
 	if(not communicationChannel_->sendMessage(&connectMessage)){
 		log::logError("Communication client couldn't send any message");

--- a/source/bringauto/external_client/connection/ExternalConnection.cpp
+++ b/source/bringauto/external_client/connection/ExternalConnection.cpp
@@ -15,16 +15,15 @@ using log = settings::Logger;
 ExternalConnection::ExternalConnection(structures::GlobalContext &context,
 									   structures::ModuleLibrary &moduleLibrary,
 									   const structures::ExternalConnectionSettings &settings,
-									   const std::shared_ptr<structures::AtomicQueue<InternalProtocol::DeviceCommand>> &commandQueue,
-									   const std::shared_ptr<structures::AtomicQueue<
-											   structures::ReconnectQueueItem>> &reconnectQueue):
+									   structures::AtomicQueue<InternalProtocol::DeviceCommand>& commandQueue,
+									   structures::AtomicQueue<structures::ReconnectQueueItem>& reconnectQueue):
 		context_ { context },
 		moduleLibrary_ { moduleLibrary },
 		settings_ { settings },
 		commandQueue_ { commandQueue },
 		reconnectQueue_ { reconnectQueue } {
 	sentMessagesHandler_ = std::make_unique<messages::SentMessagesHandler>(context_, [this]() {
-		reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
+		reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 	});
 }
 
@@ -334,7 +333,7 @@ int ExternalConnection::handleCommand(const ExternalProtocol::Command &commandMe
 	const auto &errorAggregator = it->second;
 	if(sentMessagesHandler_->isDeviceConnected(deviceId)) {
 		responseType = ExternalProtocol::CommandResponse_Type_OK;
-		commandQueue_->pushAndNotify(commandMessage.devicecommand());
+		commandQueue_.pushAndNotify(commandMessage.devicecommand());
 	} else if(errorAggregator.is_device_type_supported(deviceId.getDeviceType()) != OK) {
 		responseType = ExternalProtocol::CommandResponse_Type_DEVICE_NOT_SUPPORTED;
 	} else {
@@ -358,7 +357,7 @@ void ExternalConnection::receivingHandlerLoop() {
 		const auto serverMessage = communicationChannel_->receiveMessage();
 		if(communicationChannel_->consumeServerDisconnectNotification()) {
 			log::logInfo("External server sent disconnect notification, dropping connection until new device connects");
-			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), false));
+			reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), false));
 			return;
 		}
 		if(serverMessage == nullptr || state_.load() == ConnectionState::NOT_CONNECTED) {
@@ -368,19 +367,19 @@ void ExternalConnection::receivingHandlerLoop() {
 			const auto &command = serverMessage->command();
 			log::logDebug("Handling COMMAND messageCounter={}", command.messagecounter());
 			if(handleCommand(command) != OK) {
-				reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
+				reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 				return;
 			}
 		} else if(serverMessage->has_statusresponse()) {
 			const auto &statusResponse = serverMessage->statusresponse();
 			log::logDebug("Handling STATUS_RESPONSE messageCounter={}", statusResponse.messagecounter());
 			if(sentMessagesHandler_->acknowledgeStatus(statusResponse) != OK) {
-				reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), false));
+				reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), false));
 				return;
 			}
 		} else {
 			log::logError("Received message with unexpected type(connect response), closing connection");
-			reconnectQueue_->pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
+			reconnectQueue_.pushAndNotify(structures::ReconnectQueueItem(std::ref(*this), true));
 			return;
 		}
 

--- a/source/bringauto/external_client/connection/communication/DummyCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/DummyCommunication.cpp
@@ -28,7 +28,7 @@ bool DummyCommunication::sendMessage(ExternalProtocol::ExternalClient *message) 
     return true;
 }
 
-std::shared_ptr<ExternalProtocol::ExternalServer> DummyCommunication::receiveMessage() {
+std::unique_ptr<ExternalProtocol::ExternalServer> DummyCommunication::receiveMessage() {
     settings::Logger::logDebug("Receiving message in DummyCommunication");
     return nullptr;
 }

--- a/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/MqttCommunication.cpp
@@ -204,7 +204,7 @@ bool MqttCommunication::sendMessage(ExternalProtocol::ExternalClient* message) {
 	return true;
 }
 
-std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMessage() {
+std::unique_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMessage() {
 	std::lock_guard<std::mutex> lock(receiveMessageMutex_);
 	if(client_ == nullptr) {
 		return nullptr;
@@ -224,7 +224,7 @@ std::shared_ptr<ExternalProtocol::ExternalServer> MqttCommunication::receiveMess
 		return nullptr;
 	}
 
-	auto ptr = std::make_shared<ExternalProtocol::ExternalServer>();
+	auto ptr = std::make_unique<ExternalProtocol::ExternalServer>();
 	if (!ptr->ParseFromArray(msg->get_payload_str().c_str(), static_cast<int>(msg->get_payload_str().size()))) {
 		settings::Logger::logError("Failed to parse protobuf message from external server");
 		return nullptr;

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -156,7 +156,7 @@ namespace bringauto::external_client::connection::communication {
 			return nullptr;
 		}
 
-		auto msg = std::make_unique<ExternalProtocol::ExternalServer>(*inboundQueue_.front());
+		auto msg = std::move(inboundQueue_.front());
 		inboundQueue_.pop();
 		return msg;
 	}
@@ -283,7 +283,7 @@ namespace bringauto::external_client::connection::communication {
 	}
 
 	void QuicCommunication::onMessageDecoded(
-		std::shared_ptr<ExternalProtocol::ExternalServer> msg
+		std::unique_ptr<ExternalProtocol::ExternalServer> msg
 	) {
 		{
 			std::scoped_lock lock(inboundMutex_);
@@ -462,7 +462,7 @@ namespace bringauto::external_client::connection::communication {
 					break;
 				}
 				if (!complete.empty()) {
-					auto msg = std::make_shared<ExternalProtocol::ExternalServer>();
+					auto msg = std::make_unique<ExternalProtocol::ExternalServer>();
 					if (msg->ParseFromArray(complete.data(), static_cast<int>(complete.size()))) {
 						self->onMessageDecoded(std::move(msg));
 					} else {

--- a/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
+++ b/source/bringauto/external_client/connection/communication/QuicCommunication.cpp
@@ -124,7 +124,7 @@ namespace bringauto::external_client::connection::communication {
 		return true;
 	}
 
-	std::shared_ptr<ExternalProtocol::ExternalServer> QuicCommunication::receiveMessage() {
+	std::unique_ptr<ExternalProtocol::ExternalServer> QuicCommunication::receiveMessage() {
 		using enum ConnectionState;
 		std::unique_lock lock(inboundMutex_);
 
@@ -156,7 +156,7 @@ namespace bringauto::external_client::connection::communication {
 			return nullptr;
 		}
 
-		auto msg = inboundQueue_.front();
+		auto msg = std::make_unique<ExternalProtocol::ExternalServer>(*inboundQueue_.front());
 		inboundQueue_.pop();
 		return msg;
 	}

--- a/source/bringauto/external_client/connection/messages/SentMessagesHandler.cpp
+++ b/source/bringauto/external_client/connection/messages/SentMessagesHandler.cpp
@@ -9,7 +9,7 @@
 namespace bringauto::external_client::connection::messages {
 
 
-SentMessagesHandler::SentMessagesHandler(const std::shared_ptr<structures::GlobalContext> &context,
+SentMessagesHandler::SentMessagesHandler(structures::GlobalContext &context,
 										 const std::function<void()> &endConnectionFunc): context_ { context },
 																						 endConnectionFunc_ {
 																								 endConnectionFunc } {}
@@ -17,7 +17,7 @@ SentMessagesHandler::SentMessagesHandler(const std::shared_ptr<structures::Globa
 void SentMessagesHandler::addNotAckedStatus(const ExternalProtocol::Status &status) {
 	std::scoped_lock lock {ackMutex_};
 	notAckedStatuses_.emplace_back(
-			std::make_shared<NotAckedStatus>(status, context_->ioContext, responseHandled_, responseHandledMutex_));
+			std::make_shared<NotAckedStatus>(status, context_.ioContext, responseHandled_, responseHandledMutex_));
 	notAckedStatuses_.back()->startTimer(endConnectionFunc_);
 }
 

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -15,7 +15,7 @@ void InternalServer::run() {
 	log::logInfo("Internal server started, constants used: fleet_protocol_timeout_length: {}, queue_timeout_length: {}",
 				 settings::fleet_protocol_timeout_length.count(),
 				 settings::queue_timeout_length.count());
-	const boost::asio::ip::tcp::endpoint endpoint { boost::asio::ip::tcp::v4(), context_->settings->port };
+	const boost::asio::ip::tcp::endpoint endpoint { boost::asio::ip::tcp::v4(), context_->settings.port };
 	acceptor_.open(endpoint.protocol());
 	acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
 	acceptor_.bind(endpoint);

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -276,7 +276,7 @@ void InternalServer::handleDisconnect(const structures::DeviceIdentification& de
 void InternalServer::connectNewDevice(const std::shared_ptr<structures::Connection> &connection,
 									  const InternalProtocol::InternalClient &connect,
 									  const structures::DeviceIdentification &deviceId) {
-	connection->deviceId = std::make_shared<structures::DeviceIdentification>(deviceId);
+	connection->deviceId = deviceId;
 	connectedDevices_.push_back(connection);
 	fromInternalQueue_.pushAndNotify(structures::InternalClientMessage(false, connect));
 	log::logInfo(
@@ -394,12 +394,12 @@ void InternalServer::removeConnFromMap(const std::shared_ptr<structures::Connect
 	boost::system::error_code error {};
 	connection->socket.shutdown(boost::asio::socket_base::shutdown_both, error);
 	connection->socket.close(error);
-	if(connection->deviceId == nullptr) {
+	if(!connection->deviceId) {
 		return;
 	}
 	const auto it = std::find_if(connectedDevices_.begin(), connectedDevices_.end(),
 								 [&connection](const std::shared_ptr<structures::Connection> &toCompare) {
-									 return connection->deviceId->isSame(toCompare->deviceId);
+									 return connection->deviceId->isSame(*toCompare->deviceId);
 								 });
 
 	if(it != connectedDevices_.end() && (*it)->deviceId->getPriority() == connection->deviceId->getPriority()) {
@@ -419,7 +419,7 @@ InternalServer::findConnection(const structures::DeviceIdentification &deviceId)
 	std::shared_ptr<structures::Connection> connectionFound {};
 	const auto it = std::find_if(connectedDevices_.begin(), connectedDevices_.end(),
 						   [&deviceId](const auto& toCompare) {
-							   return deviceId.isSame(toCompare->deviceId);
+							   return deviceId.isSame(*toCompare->deviceId);
 						   });
 	if(it != connectedDevices_.end()) {
 		connectionFound = *it;

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -427,11 +427,11 @@ InternalServer::findConnection(const structures::DeviceIdentification &deviceId)
 	return connectionFound;
 }
 
-void InternalServer::destroy() {
-	log::logInfo("Internal server stopped");
+InternalServer::~InternalServer() {
 	boost::system::error_code error {};
 	acceptor_.cancel(error);
 	acceptor_.close(error);
+	log::logInfo("Internal server stopped");
 }
 
 

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -228,7 +228,7 @@ bool InternalServer::handleStatus(const std::shared_ptr<structures::Connection> 
 		return false;
 	}
 	std::lock_guard<std::mutex> lk(connection->connectionMutex);
-	fromInternalQueue_->pushAndNotify(structures::InternalClientMessage(false, client));
+	fromInternalQueue_.pushAndNotify(structures::InternalClientMessage(false, client));
 	connection->ready = false;
 	return true;
 }
@@ -278,7 +278,7 @@ void InternalServer::connectNewDevice(const std::shared_ptr<structures::Connecti
 									  const structures::DeviceIdentification &deviceId) {
 	connection->deviceId = std::make_shared<structures::DeviceIdentification>(deviceId);
 	connectedDevices_.push_back(connection);
-	fromInternalQueue_->pushAndNotify(structures::InternalClientMessage(false, connect));
+	fromInternalQueue_.pushAndNotify(structures::InternalClientMessage(false, connect));
 	log::logInfo(
 			"Connection with DeviceId(module: {}, deviceType: {}, deviceRole: {}, deviceName: {}, priority: {}) "
 			"has been added into the vector of active connections",
@@ -357,14 +357,14 @@ bool InternalServer::sendResponse(const std::shared_ptr<structures::Connection> 
 
 void InternalServer::listenToQueue() {
 	while(!context_.ioContext.stopped()) {
-		if(!toInternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
-			auto &message = toInternalQueue_->front();
+		if(!toInternalQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
+			auto &message = toInternalQueue_.front();
 			if(message.disconnected()) {
 				handleDisconnect(message.getDeviceId());
 			} else {
 				validateResponse(message.getMessage());
 			}
-			toInternalQueue_->pop();
+			toInternalQueue_.pop();
 		}
 	}
 }
@@ -409,7 +409,7 @@ void InternalServer::removeConnFromMap(const std::shared_ptr<structures::Connect
 				" has been closed and erased", connection->deviceId->getModule(),
 				connection->deviceId->getDeviceType(), connection->deviceId->getDeviceRole(),
 				connection->deviceId->getDeviceName(), connection->deviceId->getPriority());
-		fromInternalQueue_->pushAndNotify(structures::InternalClientMessage(*connection->deviceId));
+		fromInternalQueue_.pushAndNotify(structures::InternalClientMessage(*connection->deviceId));
 	}
 
 }

--- a/source/bringauto/internal_server/InternalServer.cpp
+++ b/source/bringauto/internal_server/InternalServer.cpp
@@ -15,7 +15,7 @@ void InternalServer::run() {
 	log::logInfo("Internal server started, constants used: fleet_protocol_timeout_length: {}, queue_timeout_length: {}",
 				 settings::fleet_protocol_timeout_length.count(),
 				 settings::queue_timeout_length.count());
-	const boost::asio::ip::tcp::endpoint endpoint { boost::asio::ip::tcp::v4(), context_->settings.port };
+	const boost::asio::ip::tcp::endpoint endpoint { boost::asio::ip::tcp::v4(), context_.settings.port };
 	acceptor_.open(endpoint.protocol());
 	acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
 	acceptor_.bind(endpoint);
@@ -25,10 +25,10 @@ void InternalServer::run() {
 }
 
 void InternalServer::addAsyncAccept() {
-	if(context_->ioContext.stopped()) {
+	if(context_.ioContext.stopped()) {
 		return;
 	}
-	auto connection = std::make_shared<structures::Connection>(context_->ioContext);
+	auto connection = std::make_shared<structures::Connection>(context_.ioContext);
 	acceptor_.async_accept(connection->socket, [this, connection](const boost::system::error_code &error) {
 		if(error) {
 			log::logError("Error in addAsyncAccept(): {}", error.message());
@@ -206,7 +206,7 @@ bool InternalServer::handleMessage(const std::shared_ptr<structures::Connection>
 	std::unique_lock<std::mutex> lk(connection->connectionMutex);
 	connection->conditionVariable.wait_for(lk, settings::fleet_protocol_timeout_length,
 										   [this, connection]() {
-											   return connection->ready || context_->ioContext.stopped();
+											   return connection->ready || context_.ioContext.stopped();
 										   });
 	if(!connection->ready) {
 		log::logError("Error in handleMessage(...): "
@@ -215,7 +215,7 @@ bool InternalServer::handleMessage(const std::shared_ptr<structures::Connection>
 					  connection->remoteEndpointAddress());
 		return false;
 	}
-	return !context_->ioContext.stopped();
+	return !context_.ioContext.stopped();
 }
 
 bool InternalServer::handleStatus(const std::shared_ptr<structures::Connection> &connection,
@@ -356,7 +356,7 @@ bool InternalServer::sendResponse(const std::shared_ptr<structures::Connection> 
 }
 
 void InternalServer::listenToQueue() {
-	while(!context_->ioContext.stopped()) {
+	while(!context_.ioContext.stopped()) {
 		if(!toInternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
 			auto &message = toInternalQueue_->front();
 			if(message.disconnected()) {

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -15,8 +15,8 @@ namespace bringauto::modules {
 namespace ip = InternalProtocol;
 
 void ModuleHandler::destroy() const {
-	while(not fromInternalQueue_->empty()) {
-		fromInternalQueue_->pop();
+	while(not fromInternalQueue_.empty()) {
+		fromInternalQueue_.pop();
 	}
 	while(not commandForwardingQueue_->empty()) {
 		commandForwardingQueue_->pop();
@@ -33,13 +33,13 @@ void ModuleHandler::run() const {
 
 void ModuleHandler::handleMessages() const {
 	while(not context_.ioContext.stopped()) {
-		if(fromInternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+		if(fromInternalQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
 			checkTimeoutedMessages();
 			continue;
 		}
 		checkTimeoutedMessages();
 
-		auto &message = fromInternalQueue_->front();
+		auto &message = fromInternalQueue_.front();
 		if(message.disconnected()) {
 			handleDisconnect(message.getDeviceId());
 		} else if(message.getMessage().has_deviceconnect()) {
@@ -47,7 +47,7 @@ void ModuleHandler::handleMessages() const {
 		} else if(message.getMessage().has_devicestatus()) {
 			handleStatus(message.getMessage().devicestatus());
 		}
-		fromInternalQueue_->pop();
+		fromInternalQueue_.pop();
 	}
 }
 
@@ -81,15 +81,15 @@ void ModuleHandler::checkTimeoutedMessages() const {
 					const auto internalProtocolDevice = device.convertToIPDevice();
 					auto statusMessage = common_utils::ProtobufUtils::createInternalClientStatusMessage(internalProtocolDevice,
 																										aggregatedStatusBuffer);
-					toExternalQueue_->pushAndNotify(structures::InternalClientMessage(false, statusMessage));
+					toExternalQueue_.pushAndNotify(structures::InternalClientMessage(false, statusMessage));
 					settings::Logger::logDebug("Module handler pushed a timed out aggregated status, number of aggregated statuses in queue {}",
-								  toExternalQueue_->size());
+								  toExternalQueue_.size());
 					checkExternalQueueSize();
 				}
 
 				if(statusAggregator->getDeviceTimeoutCount(device) >= settings::status_aggregation_timeout_max_count){
 					settings::Logger::logWarning("Device {} not sending statuses for too long, disconnecting it", device.convertToString());
-					toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(device));
+					toInternalQueue_.pushAndNotify(structures::ModuleHandlerMessage(device));
 				}
 			}
 			statusAggregator->unsetTimeoutedMessageReady();
@@ -132,9 +132,9 @@ void ModuleHandler::sendAggregatedStatus(const structures::DeviceIdentification 
 	Buffer aggregatedStatusBuffer {};
 	statusAggregator->get_aggregated_status(aggregatedStatusBuffer, deviceId);
 	const auto statusMessage = common_utils::ProtobufUtils::createInternalClientStatusMessage(device, aggregatedStatusBuffer);
-	toExternalQueue_->pushAndNotify(structures::InternalClientMessage(disconnected, statusMessage));
+	toExternalQueue_.pushAndNotify(structures::InternalClientMessage(disconnected, statusMessage));
 	settings::Logger::logDebug("Module handler pushed aggregated status, number of aggregated statuses in queue {}",
-				  toExternalQueue_->size());
+				  toExternalQueue_.size());
 	checkExternalQueueSize();
 }
 
@@ -169,7 +169,7 @@ void ModuleHandler::handleConnect(const ip::DeviceConnect &connect) const {
 void
 ModuleHandler::sendConnectResponse(const ip::Device &device, ip::DeviceConnectResponse_ResponseType response_type) const {
 	const auto response = common_utils::ProtobufUtils::createInternalServerConnectResponseMessage(device, response_type);
-	toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false,response));
+	toInternalQueue_.pushAndNotify(structures::ModuleHandlerMessage(false,response));
 	settings::Logger::logInfo("New device {} is trying to connect, sending response {}", device.devicename(), static_cast<int>(response_type));
 }
 
@@ -237,7 +237,7 @@ void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {
 	if(getCommandRc == OK) {
 		const auto deviceCommandMessage = common_utils::ProtobufUtils::createInternalServerCommandMessage(device,
 																									commandBuffer);
-		toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
+		toInternalQueue_.pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
 		settings::Logger::logDebug("Module handler successfully retrieved command and sent it to device: {}", deviceName);
 	} else if(getCommandRc == NO_MESSAGE_AVAILABLE) {
 		// Push-only device with no fresh command from ES. Send an empty DeviceCommand to
@@ -260,7 +260,7 @@ void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {
 }
 
 void ModuleHandler::checkExternalQueueSize() const {
-	if(toExternalQueue_->size() > settings::max_external_queue_size) {
+	if(toExternalQueue_.size() > settings::max_external_queue_size) {
 		settings::Logger::logError("External queue size is too big, external client is not handling messages");
 		//temporarily disabled to verify if the bug related to deadlocks is fixed
 		//destroy();

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -14,13 +14,18 @@ namespace bringauto::modules {
 
 namespace ip = InternalProtocol;
 
-void ModuleHandler::destroy() const {
-	while(not fromInternalQueue_.empty()) {
-		fromInternalQueue_.pop();
-	}
-	while(not commandForwardingQueue_->empty()) {
-		commandForwardingQueue_->pop();
-	}
+ModuleHandler::ModuleHandler(structures::GlobalContext& context, structures::ModuleLibrary& moduleLibrary,
+	structures::AtomicQueue<structures::InternalClientMessage>& fromInternalQueue,
+	structures::AtomicQueue<structures::InternalClientMessage>& commandForwardingQueue,
+	structures::AtomicQueue<structures::ModuleHandlerMessage>& toInternalQueue,
+	structures::AtomicQueue<structures::InternalClientMessage>& toExternalQueue): context_{context}, moduleLibrary_{moduleLibrary}, fromInternalQueue_{fromInternalQueue},
+	commandForwardingQueue_{commandForwardingQueue},
+	toInternalQueue_{toInternalQueue},
+	toExternalQueue_{toExternalQueue}
+{
+}
+
+ModuleHandler::~ModuleHandler() {
 	settings::Logger::logInfo("Module handler stopped");
 }
 
@@ -53,11 +58,11 @@ void ModuleHandler::handleMessages() const {
 
 void ModuleHandler::handleCommandForwards() const {
 	while(not context_.ioContext.stopped()) {
-		if(commandForwardingQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
+		if(commandForwardingQueue_.waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
-		handleCommandForward(commandForwardingQueue_->front().getDeviceId());
-		commandForwardingQueue_->pop();
+		handleCommandForward(commandForwardingQueue_.front().getDeviceId());
+		commandForwardingQueue_.pop();
 	}
 }
 
@@ -246,7 +251,7 @@ void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {
 		// timeout trigger the safe-stop.
 		const auto emptyCommandMessage = common_utils::ProtobufUtils::createInternalServerCommandMessage(
 			device, Buffer{});
-		toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, emptyCommandMessage));
+		toInternalQueue_.pushAndNotify(structures::ModuleHandlerMessage(false, emptyCommandMessage));
 		settings::Logger::logDebug("No fresh command for push-only device {}, sending empty response", deviceName);
 	} else {
 		settings::Logger::logWarning("Retrieving command failed with return code: {}", getCommandRc);
@@ -262,9 +267,6 @@ void ModuleHandler::handleStatus(const ip::DeviceStatus &status) const {
 void ModuleHandler::checkExternalQueueSize() const {
 	if(toExternalQueue_.size() > settings::max_external_queue_size) {
 		settings::Logger::logError("External queue size is too big, external client is not handling messages");
-		//temporarily disabled to verify if the bug related to deadlocks is fixed
-		//destroy();
-		//throw std::runtime_error("External queue size is too big");
 	}
 }
 

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -32,7 +32,7 @@ void ModuleHandler::run() const {
 }
 
 void ModuleHandler::handleMessages() const {
-	while(not context_->ioContext.stopped()) {
+	while(not context_.ioContext.stopped()) {
 		if(fromInternalQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
 			checkTimeoutedMessages();
 			continue;

--- a/source/bringauto/modules/ModuleHandler.cpp
+++ b/source/bringauto/modules/ModuleHandler.cpp
@@ -52,7 +52,7 @@ void ModuleHandler::handleMessages() const {
 }
 
 void ModuleHandler::handleCommandForwards() const {
-	while(not context_->ioContext.stopped()) {
+	while(not context_.ioContext.stopped()) {
 		if(commandForwardingQueue_->waitForValueWithTimeout(settings::queue_timeout_length)) {
 			continue;
 		}
@@ -195,7 +195,7 @@ void ModuleHandler::handleCommandForward(const structures::DeviceIdentification 
 
 	const auto device = deviceId.convertToIPDevice();
 	const auto deviceCommandMessage = common_utils::ProtobufUtils::createInternalServerCommandMessage(device, commandBuffer);
-	toInternalQueue_->pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
+	toInternalQueue_.pushAndNotify(structures::ModuleHandlerMessage(false, deviceCommandMessage));
 	settings::Logger::logDebug("Module handler forwarded command immediately for device: {}", deviceId.getDeviceName());
 }
 

--- a/source/bringauto/modules/StatusAggregator.cpp
+++ b/source/bringauto/modules/StatusAggregator.cpp
@@ -78,7 +78,7 @@ int StatusAggregator::remove_device(const structures::DeviceIdentification& devi
 	}
 	clearDeviceUnlocked(device);
 
-	boost::asio::post(context_->ioContext, [this, device]() {
+	boost::asio::post(context_.ioContext, [this, device]() {
 		std::lock_guard postLock(devicesMutex_);
 		devices.erase(device);
 	});

--- a/source/bringauto/settings/SettingsParser.cpp
+++ b/source/bringauto/settings/SettingsParser.cpp
@@ -88,30 +88,30 @@ bool SettingsParser::areCmdArgumentsCorrect() const {
 bool SettingsParser::areSettingsCorrect() const {
 	bool isCorrect = true;
 
-	if(settings_->loggingSettings.file.use && !std::filesystem::exists(settings_->loggingSettings.file.path)) {
-		std::cerr << "Given log path (" << settings_->loggingSettings.file.path << ") does not exist." << std::endl;
+	if(settings_.loggingSettings.file.use && !std::filesystem::exists(settings_.loggingSettings.file.path)) {
+		std::cerr << "Given log path (" << settings_.loggingSettings.file.path << ") does not exist." << std::endl;
 		isCorrect = false;
 	}
-	if(settings_->modulePaths.empty()) {
+	if(settings_.modulePaths.empty()) {
 		std::cerr << "No shared module library provided." << std::endl;
 		isCorrect = false;
 	}
-	if(!settings_->moduleBinaryPath.empty() && !std::filesystem::exists(settings_->moduleBinaryPath)) {
-		std::cerr << "Given module binary path (" << settings_->moduleBinaryPath << ") does not exist." << std::endl;
+	if(!settings_.moduleBinaryPath.empty() && !std::filesystem::exists(settings_.moduleBinaryPath)) {
+		std::cerr << "Given module binary path (" << settings_.moduleBinaryPath << ") does not exist." << std::endl;
 		isCorrect = false;
 	}
-	if(!std::regex_match(settings_->company, std::regex("^[a-z0-9_]+$"))) {
-		std::cerr << "Company name (" << settings_->company << ") is not valid." << std::endl;
+	if(!std::regex_match(settings_.company, std::regex("^[a-z0-9_]+$"))) {
+		std::cerr << "Company name (" << settings_.company << ") is not valid." << std::endl;
 		isCorrect = false;
 	}
-	if(!std::regex_match(settings_->vehicleName, std::regex("^[a-z0-9_]+$"))) {
-		std::cerr << "Vehicle name (" << settings_->vehicleName << ") is not valid." << std::endl;
+	if(!std::regex_match(settings_.vehicleName, std::regex("^[a-z0-9_]+$"))) {
+		std::cerr << "Vehicle name (" << settings_.vehicleName << ") is not valid." << std::endl;
 		isCorrect = false;
 	}
 
-	for(auto& externalConnectionSettings: settings_->externalConnectionSettingsList) {
+	for(auto& externalConnectionSettings: settings_.externalConnectionSettingsList) {
 		for(auto const& externalModuleId: externalConnectionSettings.modules) {
-			if(!settings_->modulePaths.contains(externalModuleId)) {
+			if(!settings_.modulePaths.contains(externalModuleId)) {
 				std::cerr << "Module " << externalModuleId <<
 				" is defined in external-connection endpoint modules but is not specified in module-paths" << std::endl;
 				isCorrect = false;
@@ -121,12 +121,12 @@ bool SettingsParser::areSettingsCorrect() const {
 	return isCorrect;
 }
 
-std::shared_ptr<Settings> SettingsParser::getSettings() {
+const Settings& SettingsParser::getSettings() {
 	return settings_;
 }
 
 void SettingsParser::fillSettings() {
-	settings_ = std::make_shared<Settings>();
+	settings_ = {};
 
 	const auto configPath = cmdArguments_[std::string(Constants::CONFIG_PATH)].as<std::string>();
 	std::ifstream inputFile(configPath);
@@ -138,32 +138,32 @@ void SettingsParser::fillSettings() {
 	fillExternalConnectionSettings(file);
 }
 
-void SettingsParser::fillLoggingSettings(const nlohmann::json &file) const {
+void SettingsParser::fillLoggingSettings(const nlohmann::json &file) {
 	const auto &consoleLogging = file[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_CONSOLE)];
 	const auto &fileLogging = file[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_FILE)];
 
-	settings_->loggingSettings.console.use = consoleLogging[std::string(Constants::LOG_USE)];
-	settings_->loggingSettings.console.level = common_utils::EnumUtils::stringToLoggerVerbosity(
+	settings_.loggingSettings.console.use = consoleLogging[std::string(Constants::LOG_USE)];
+	settings_.loggingSettings.console.level = common_utils::EnumUtils::stringToLoggerVerbosity(
 		consoleLogging[std::string(Constants::LOG_LEVEL)]);
 
-	settings_->loggingSettings.file.use = fileLogging[std::string(Constants::LOG_USE)];
-	settings_->loggingSettings.file.level = common_utils::EnumUtils::stringToLoggerVerbosity(
+	settings_.loggingSettings.file.use = fileLogging[std::string(Constants::LOG_USE)];
+	settings_.loggingSettings.file.level = common_utils::EnumUtils::stringToLoggerVerbosity(
 		fileLogging[std::string(Constants::LOG_LEVEL)]);
-	settings_->loggingSettings.file.path = std::filesystem::path(fileLogging[std::string(Constants::LOG_PATH)]);
+	settings_.loggingSettings.file.path = std::filesystem::path(fileLogging[std::string(Constants::LOG_PATH)]);
 }
 
-void SettingsParser::fillInternalServerSettings(const nlohmann::json &file) const {
+void SettingsParser::fillInternalServerSettings(const nlohmann::json &file) {
 	if(cmdArguments_.count(std::string(Constants::PORT))) {
-		settings_->port = cmdArguments_[std::string(Constants::PORT)].as<int>();
+		settings_.port = cmdArguments_[std::string(Constants::PORT)].as<int>();
 	} else {
-		settings_->port = file[std::string(Constants::INTERNAL_SERVER_SETTINGS)][std::string(Constants::PORT)];
+		settings_.port = file[std::string(Constants::INTERNAL_SERVER_SETTINGS)][std::string(Constants::PORT)];
 	}
 }
 
-void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
+void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) {
 	for(auto &[key, val]: file[std::string(Constants::MODULE_PATHS)].items()) {
 		try {
-			settings_->modulePaths[stoi(key)] = val.get<std::string>();
+			settings_.modulePaths[stoi(key)] = val.get<std::string>();
 		} catch(const std::invalid_argument &) {
 			throw std::invalid_argument { "Module path key '" + key + "' is not a valid integer module number" };
 		} catch(const std::out_of_range &) {
@@ -171,15 +171,15 @@ void SettingsParser::fillModulePathsSettings(const nlohmann::json &file) const {
 		}
 	}
 	if(file.contains(std::string(Constants::MODULE_BINARY_PATH))) {
-		settings_->moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
+		settings_.moduleBinaryPath = file.at(std::string(Constants::MODULE_BINARY_PATH)).get<std::string>();
 	}
 }
 
-void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) const {
+void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) {
 	file.at(std::string(Constants::EXTERNAL_CONNECTION)).at(std::string(Constants::VEHICLE_NAME)).get_to(
-			settings_->vehicleName);
+			settings_.vehicleName);
 	file.at(std::string(Constants::EXTERNAL_CONNECTION)).at(std::string(Constants::COMPANY)).get_to(
-			settings_->company);
+			settings_.company);
 
 	for(const auto &endpoint: file[std::string(Constants::EXTERNAL_CONNECTION)][std::string(
 			Constants::EXTERNAL_ENDPOINTS)]) {
@@ -213,7 +213,7 @@ void SettingsParser::fillExternalConnectionSettings(const nlohmann::json &file) 
 			}
 		}
 
-		settings_->externalConnectionSettingsList.push_back(externalConnectionSettings);
+		settings_.externalConnectionSettingsList.push_back(externalConnectionSettings);
 	}
 }
 
@@ -221,25 +221,25 @@ std::string SettingsParser::serializeToJson() const {
 	nlohmann::json settingsAsJson {};
 
 	settingsAsJson[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_CONSOLE)]
-		[std::string(Constants::LOG_USE)] = settings_->loggingSettings.console.use;
+		[std::string(Constants::LOG_USE)] = settings_.loggingSettings.console.use;
 	settingsAsJson[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_CONSOLE)][std::string(Constants::LOG_LEVEL)] =
-		common_utils::EnumUtils::loggerVerbosityToString(settings_->loggingSettings.console.level);
+		common_utils::EnumUtils::loggerVerbosityToString(settings_.loggingSettings.console.level);
 	settingsAsJson[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_FILE)]
-		[std::string(Constants::LOG_USE)] = settings_->loggingSettings.file.use;
+		[std::string(Constants::LOG_USE)] = settings_.loggingSettings.file.use;
 	settingsAsJson[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_FILE)][std::string(Constants::LOG_LEVEL)] =
-		common_utils::EnumUtils::loggerVerbosityToString(settings_->loggingSettings.file.level);
+		common_utils::EnumUtils::loggerVerbosityToString(settings_.loggingSettings.file.level);
 	settingsAsJson[std::string(Constants::LOGGING)][std::string(Constants::LOGGING_FILE)]
-		[std::string(Constants::LOG_PATH)] = settings_->loggingSettings.file.path;
+		[std::string(Constants::LOG_PATH)] = settings_.loggingSettings.file.path;
 
-	settingsAsJson[std::string(Constants::INTERNAL_SERVER_SETTINGS)][std::string(Constants::PORT)] = settings_->port;
-	for(const auto &[key, val]: settings_->modulePaths) {
+	settingsAsJson[std::string(Constants::INTERNAL_SERVER_SETTINGS)][std::string(Constants::PORT)] = settings_.port;
+	for(const auto &[key, val]: settings_.modulePaths) {
 		settingsAsJson[std::string(Constants::MODULE_PATHS)][std::to_string(key)] = val.string();
 	}
 
-	settingsAsJson[std::string(Constants::EXTERNAL_CONNECTION)][std::string(Constants::COMPANY)] = settings_->company;
-	settingsAsJson[std::string(Constants::EXTERNAL_CONNECTION)][std::string(Constants::VEHICLE_NAME)] = settings_->vehicleName;
+	settingsAsJson[std::string(Constants::EXTERNAL_CONNECTION)][std::string(Constants::COMPANY)] = settings_.company;
+	settingsAsJson[std::string(Constants::EXTERNAL_CONNECTION)][std::string(Constants::VEHICLE_NAME)] = settings_.vehicleName;
 	nlohmann::json::array_t endpoints {};
-	for(const auto &endpoint: settings_->externalConnectionSettingsList) {
+	for(const auto &endpoint: settings_.externalConnectionSettingsList) {
 		nlohmann::json endpointAsJson {};
 		endpointAsJson[std::string(Constants::SERVER_IP)] = endpoint.serverIp;
 		endpointAsJson[std::string(Constants::PORT)] = endpoint.port;

--- a/source/bringauto/structures/DeviceIdentification.cpp
+++ b/source/bringauto/structures/DeviceIdentification.cpp
@@ -39,10 +39,10 @@ const std::string &DeviceIdentification::getDeviceName() const {
 	return deviceName_;
 }
 
-bool DeviceIdentification::isSame(const std::shared_ptr<DeviceIdentification> &toCompare) const {
-	return module_ == toCompare->getModule() &&
-		   deviceType_ == toCompare->getDeviceType() &&
-		   deviceRole_ == toCompare->getDeviceRole();
+bool DeviceIdentification::isSame(const DeviceIdentification &toCompare) const {
+	return module_ == toCompare.getModule() &&
+		   deviceType_ == toCompare.getDeviceType() &&
+		   deviceRole_ == toCompare.getDeviceRole();
 }
 
 DeviceIdentification& DeviceIdentification::operator=(const InternalProtocol::Device &device) {

--- a/source/bringauto/structures/ModuleLibrary.cpp
+++ b/source/bringauto/structures/ModuleLibrary.cpp
@@ -51,7 +51,7 @@ void ModuleLibrary::initStatusAggregators(std::shared_ptr<GlobalContext> &contex
 		}
 
 		bool found = false;
-		for(const auto &connection: context->settings->externalConnectionSettingsList) {
+		for(const auto &connection: context->settings.externalConnectionSettingsList) {
 			const auto &modules = connection.modules;
 			if(std::find(modules.cbegin(), modules.cend(), moduleNumber) != modules.cend()) {
 				statusAggregators.try_emplace(moduleNumber, statusAggregator);

--- a/source/bringauto/structures/ModuleLibrary.cpp
+++ b/source/bringauto/structures/ModuleLibrary.cpp
@@ -39,7 +39,7 @@ void ModuleLibrary::loadLibraries(const std::unordered_map<int, std::filesystem:
 	}
 }
 
-void ModuleLibrary::initStatusAggregators(std::shared_ptr<GlobalContext> &context) {
+void ModuleLibrary::initStatusAggregators(GlobalContext &context) {
 	for(auto const &[key, libraryHandler]: moduleLibraryHandlers) {
 		auto statusAggregator = std::make_shared<modules::StatusAggregator>(context, libraryHandler);
 		statusAggregator->init_status_aggregator();
@@ -51,7 +51,7 @@ void ModuleLibrary::initStatusAggregators(std::shared_ptr<GlobalContext> &contex
 		}
 
 		bool found = false;
-		for(const auto &connection: context->settings.externalConnectionSettingsList) {
+		for(const auto &connection: context.settings.externalConnectionSettingsList) {
 			const auto &modules = connection.modules;
 			if(std::find(modules.cbegin(), modules.cend(), moduleNumber) != modules.cend()) {
 				statusAggregators.try_emplace(moduleNumber, statusAggregator);

--- a/source/bringauto/structures/StatusAggregatorDeviceState.cpp
+++ b/source/bringauto/structures/StatusAggregatorDeviceState.cpp
@@ -7,7 +7,7 @@
 namespace bringauto::structures {
 
 StatusAggregatorDeviceState::StatusAggregatorDeviceState(
-		std::shared_ptr<GlobalContext> &context,
+		GlobalContext &context,
 		std::function<int(const DeviceIdentification&)> fun, const DeviceIdentification &deviceId,
 		const modules::Buffer& command, const modules::Buffer& status
 		): status_ { status } {

--- a/test/include/ExternalConnectionTests.hpp
+++ b/test/include/ExternalConnectionTests.hpp
@@ -5,7 +5,6 @@
 #include <bringauto/settings/LoggerId.hpp>
 #include <testing_utils/CommunicationMock.hpp>
 
-#include <libbringauto_logger/bringauto/logging/Logger.hpp>
 #include <libbringauto_logger/bringauto/logging/FileSink.hpp>
 #include <libbringauto_logger/bringauto/logging/ConsoleSink.hpp>
 #include <gtest/gtest.h>
@@ -15,8 +14,7 @@
 class ExternalConnectionTests: public ::testing::Test {
 protected:
 	void SetUp() override {
-		context_ = std::make_shared<bringauto::structures::GlobalContext>();
-		bringauto::settings::Settings settings = {
+		context_ = std::make_shared<bringauto::structures::GlobalContext>(bringauto::settings::Settings {
 			.port = 0,
 			.modulePaths = {{ MODULE, PATH_TO_MODULE }},
 			.externalConnectionSettingsList = {{
@@ -26,12 +24,11 @@ protected:
 				0,                                            // port
 				{ MODULE }                                    // module numbers
 			}}
-		};
-		context_->settings = std::make_shared<bringauto::settings::Settings>(settings);
+		});
 
 		moduleLibrary_ = std::make_shared<bringauto::structures::ModuleLibrary>();
 		try {
-			moduleLibrary_->loadLibraries(context_->settings->modulePaths);
+			moduleLibrary_->loadLibraries(context_->settings.modulePaths);
 			moduleLibrary_->initStatusAggregators(context_);
 		} catch(std::exception &e) {
 			GTEST_FAIL() << "Module initialization failed: " << e.what();
@@ -43,12 +40,12 @@ protected:
 		externalConnection_ = std::make_unique<bringauto::external_client::connection::ExternalConnection>(
 			context_,
 			*moduleLibrary_,
-			context_->settings->externalConnectionSettingsList[0],
+			context_->settings.externalConnectionSettingsList[0],
 			fromExternalQueue_,
 			reconnectQueue_
 		);
 
-		communicationChannel_ = std::make_shared<testing_utils::CommunicationMock>(context_->settings->externalConnectionSettingsList[0]);
+		communicationChannel_ = std::make_shared<testing_utils::CommunicationMock>(context_->settings.externalConnectionSettingsList[0]);
 		externalConnection_->init(communicationChannel_);
 		auto roleBuffer = create_buffer("role");
 		auto nameBuffer = create_buffer("name");
@@ -59,7 +56,7 @@ protected:
 			.device_name = nameBuffer.getStructBuffer(),
 			.priority = 0
 		};
-		connectedDevices_.emplace_back(bringauto::structures::DeviceIdentification(device));
+		connectedDevices_.emplace_back(device);
 		externalConnection_->fillErrorAggregator(bringauto::common_utils::ProtobufUtils::createDeviceStatus(
 			connectedDevices_[0], create_buffer("status")));
 	};

--- a/test/include/ExternalConnectionTests.hpp
+++ b/test/include/ExternalConnectionTests.hpp
@@ -34,15 +34,15 @@ protected:
 			GTEST_FAIL() << "Module initialization failed: " << e.what();
 		}
 
-		fromExternalQueue_ = std::make_shared<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand >>();
-		reconnectQueue_ = std::make_shared<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem >>();
+		fromExternalQueue_ = std::make_unique<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand>>();
+		reconnectQueue_ = std::make_unique<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem>>();
 
 		externalConnection_ = std::make_unique<bringauto::external_client::connection::ExternalConnection>(
 			*context_,
 			*moduleLibrary_,
 			context_->settings.externalConnectionSettingsList[0],
-			fromExternalQueue_,
-			reconnectQueue_
+			*fromExternalQueue_,
+			*reconnectQueue_
 		);
 
 		communicationChannel_ = std::make_shared<testing_utils::CommunicationMock>(context_->settings.externalConnectionSettingsList[0]);
@@ -95,8 +95,8 @@ protected:
 
 	std::unique_ptr<bringauto::structures::GlobalContext> context_ {};
 	std::shared_ptr<bringauto::structures::ModuleLibrary> moduleLibrary_ {};
-	std::shared_ptr<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand>> fromExternalQueue_ {};
-	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem>> reconnectQueue_ {};
+	std::unique_ptr<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand>> fromExternalQueue_;
+	std::unique_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem>> reconnectQueue_;
 	std::shared_ptr<testing_utils::CommunicationMock> communicationChannel_ {};
 	std::vector<bringauto::structures::DeviceIdentification> connectedDevices_ {};
 	std::unique_ptr<bringauto::external_client::connection::ExternalConnection> externalConnection_ {};

--- a/test/include/ExternalConnectionTests.hpp
+++ b/test/include/ExternalConnectionTests.hpp
@@ -14,7 +14,7 @@
 class ExternalConnectionTests: public ::testing::Test {
 protected:
 	void SetUp() override {
-		context_ = std::make_shared<bringauto::structures::GlobalContext>(bringauto::settings::Settings {
+		context_ = std::make_unique<bringauto::structures::GlobalContext>(bringauto::settings::Settings {
 			.port = 0,
 			.modulePaths = {{ MODULE, PATH_TO_MODULE }},
 			.externalConnectionSettingsList = {{
@@ -29,7 +29,7 @@ protected:
 		moduleLibrary_ = std::make_shared<bringauto::structures::ModuleLibrary>();
 		try {
 			moduleLibrary_->loadLibraries(context_->settings.modulePaths);
-			moduleLibrary_->initStatusAggregators(context_);
+			moduleLibrary_->initStatusAggregators(*context_);
 		} catch(std::exception &e) {
 			GTEST_FAIL() << "Module initialization failed: " << e.what();
 		}
@@ -38,7 +38,7 @@ protected:
 		reconnectQueue_ = std::make_shared<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem >>();
 
 		externalConnection_ = std::make_unique<bringauto::external_client::connection::ExternalConnection>(
-			context_,
+			*context_,
 			*moduleLibrary_,
 			context_->settings.externalConnectionSettingsList[0],
 			fromExternalQueue_,
@@ -65,13 +65,13 @@ protected:
 		if(externalConnection_) {
 			externalConnection_->deinitializeConnection(true);
 		}
-		context_.reset();
+		externalConnection_.reset();   // must be before context_.reset()
 		moduleLibrary_.reset();
 		fromExternalQueue_.reset();
 		reconnectQueue_.reset();
 		communicationChannel_.reset();
 		connectedDevices_.clear();
-		externalConnection_.reset();
+		context_.reset();              // context outlives connection
 	};
 
 	static void SetUpTestSuite() {
@@ -93,7 +93,7 @@ protected:
 		ASSERT_EQ(externalConnection_->getState(), bringauto::external_client::connection::ConnectionState::NOT_CONNECTED);
 	}
 
-	std::shared_ptr<bringauto::structures::GlobalContext> context_ {};
+	std::unique_ptr<bringauto::structures::GlobalContext> context_ {};
 	std::shared_ptr<bringauto::structures::ModuleLibrary> moduleLibrary_ {};
 	std::shared_ptr<bringauto::structures::AtomicQueue<InternalProtocol::DeviceCommand>> fromExternalQueue_ {};
 	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ReconnectQueueItem>> reconnectQueue_ {};

--- a/test/include/StatusAggregatorTests.hpp
+++ b/test/include/StatusAggregatorTests.hpp
@@ -35,7 +35,7 @@ protected:
 
 	void remove_device_from_status_aggregator();
 
-	std::shared_ptr<bringauto::structures::GlobalContext> context_ {};
+	std::unique_ptr<bringauto::structures::GlobalContext> context_ {};
 
 	std::unique_ptr <bringauto::modules::StatusAggregator> statusAggregator_ {};
 

--- a/test/include/testing_utils/CommunicationMock.hpp
+++ b/test/include/testing_utils/CommunicationMock.hpp
@@ -18,7 +18,7 @@ public:
 
 	bool sendMessage(ExternalProtocol::ExternalClient *message) override;
 
-	std::shared_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
+	std::unique_ptr<ExternalProtocol::ExternalServer> receiveMessage() override;
 
 	void closeConnection() override;
 

--- a/test/include/testing_utils/InternalClientForTesting.hpp
+++ b/test/include/testing_utils/InternalClientForTesting.hpp
@@ -18,11 +18,11 @@ const size_t bufferLength { 1024 };
 const size_t headerSize { 4 };
 
 class ClientForTesting {
-	const std::shared_ptr<bringauto::structures::GlobalContext> context {};
+	bringauto::structures::GlobalContext& context;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket {};
 public:
 
-	explicit ClientForTesting(const std::shared_ptr<bringauto::structures::GlobalContext> &context_)
+	explicit ClientForTesting(bringauto::structures::GlobalContext &context_)
 		: context(context_) {}
 
 	void connectSocket();

--- a/test/include/testing_utils/ModuleHandlerForTesting.hpp
+++ b/test/include/testing_utils/ModuleHandlerForTesting.hpp
@@ -18,7 +18,7 @@ const std::chrono::seconds queue_timeout_length { 3 };
 class ModuleHandlerForTesting {
 public:
 	ModuleHandlerForTesting(
-		const std::shared_ptr<bringauto::structures::GlobalContext> &context_,
+		bringauto::structures::GlobalContext &context_,
 		const std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> &fromInternalQueue,
 		const std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> &toInternalQueue,
 		size_t num)
@@ -30,7 +30,7 @@ public:
 	void startWithTimeout(bool onConnect, size_t timeoutNumber);
 
 private:
-	std::shared_ptr<bringauto::structures::GlobalContext> context {};
+	bringauto::structures::GlobalContext& context;
 	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> fromInternalQueue_ {};
 	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> toInternalQueue_ {};
 	size_t expectedMessageNumber;

--- a/test/include/testing_utils/ModuleHandlerForTesting.hpp
+++ b/test/include/testing_utils/ModuleHandlerForTesting.hpp
@@ -19,8 +19,8 @@ class ModuleHandlerForTesting {
 public:
 	ModuleHandlerForTesting(
 		bringauto::structures::GlobalContext &context_,
-		const std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> &fromInternalQueue,
-		const std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> &toInternalQueue,
+		bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>& fromInternalQueue,
+		bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>& toInternalQueue,
 		size_t num)
 		: context(context_), fromInternalQueue_ { fromInternalQueue }, toInternalQueue_ { toInternalQueue },
 		expectedMessageNumber(num) {}
@@ -31,8 +31,8 @@ public:
 
 private:
 	bringauto::structures::GlobalContext& context;
-	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> fromInternalQueue_ {};
-	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> toInternalQueue_ {};
+	bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>& fromInternalQueue_;
+	bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>& toInternalQueue_;
 	size_t expectedMessageNumber;
 };
 

--- a/test/include/testing_utils/TestHandler.hpp
+++ b/test/include/testing_utils/TestHandler.hpp
@@ -26,7 +26,7 @@ class TestHandler {
 	std::vector<InternalProtocol::InternalClient> statuses {};
 	std::vector<InternalProtocol::InternalServer> commands {};
 	std::vector<InternalProtocol::InternalServer> responses {};
-	std::vector<std::shared_ptr<bringauto::structures::GlobalContext>> contexts {};
+	std::vector<std::unique_ptr<bringauto::structures::GlobalContext>> contexts {};
 
 	std::vector<testing_utils::ClientForTesting> clients {};
 	size_t expectedMessageNumber { 0 };

--- a/test/include/testing_utils/TestHandler.hpp
+++ b/test/include/testing_utils/TestHandler.hpp
@@ -17,7 +17,7 @@ const size_t numberOfMessages { 100 };
 const unsigned short port { 8888 };
 
 class TestHandler {
-	std::shared_ptr<bringauto::settings::Settings> settings {};
+	bringauto::settings::Settings settings {};
 
 	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> toInternalQueue {};
 	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> fromInternalQueue {};

--- a/test/include/testing_utils/TestHandler.hpp
+++ b/test/include/testing_utils/TestHandler.hpp
@@ -19,8 +19,8 @@ const unsigned short port { 8888 };
 class TestHandler {
 	bringauto::settings::Settings settings {};
 
-	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage>> toInternalQueue {};
-	std::shared_ptr<bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage>> fromInternalQueue {};
+	bringauto::structures::AtomicQueue<bringauto::structures::ModuleHandlerMessage> toInternalQueue {};
+	bringauto::structures::AtomicQueue<bringauto::structures::InternalClientMessage> fromInternalQueue {};
 
 	std::vector<InternalProtocol::InternalClient> connects {};
 	std::vector<InternalProtocol::InternalClient> statuses {};

--- a/test/source/SettingsParserTests.cpp
+++ b/test/source/SettingsParserTests.cpp
@@ -15,21 +15,21 @@ TEST_F(SettingsParserTests, ValidConfig) {
 	EXPECT_TRUE(result);
 
 	auto settings = settingsParser.getSettings();
-	EXPECT_EQ(settings->port, config.internal_server_settings.port);
-	EXPECT_EQ(settings->modulePaths, config.module_paths);
+	EXPECT_EQ(settings.port, config.internal_server_settings.port);
+	EXPECT_EQ(settings.modulePaths, config.module_paths);
 
 	auto logging = config.logging;
-	EXPECT_EQ(bacu::EnumUtils::loggerVerbosityToString(settings->loggingSettings.console.level), logging.console.level);
-	EXPECT_EQ(settings->loggingSettings.console.use, logging.console.use);
-	EXPECT_EQ(bacu::EnumUtils::loggerVerbosityToString(settings->loggingSettings.file.level), logging.file.level);
-	EXPECT_EQ(settings->loggingSettings.file.use, logging.file.use);
-	EXPECT_EQ(settings->loggingSettings.file.path, logging.file.path);
+	EXPECT_EQ(bacu::EnumUtils::loggerVerbosityToString(settings.loggingSettings.console.level), logging.console.level);
+	EXPECT_EQ(settings.loggingSettings.console.use, logging.console.use);
+	EXPECT_EQ(bacu::EnumUtils::loggerVerbosityToString(settings.loggingSettings.file.level), logging.file.level);
+	EXPECT_EQ(settings.loggingSettings.file.use, logging.file.use);
+	EXPECT_EQ(settings.loggingSettings.file.path, logging.file.path);
 
-	EXPECT_EQ(settings->company, config.external_connection.company);
-	EXPECT_EQ(settings->vehicleName, config.external_connection.vehicle_name);
+	EXPECT_EQ(settings.company, config.external_connection.company);
+	EXPECT_EQ(settings.vehicleName, config.external_connection.vehicle_name);
 
 	auto endpoint = config.external_connection.endpoint;
-	auto externalConnectionSettings = settings->externalConnectionSettingsList.front();
+	auto externalConnectionSettings = settings.externalConnectionSettingsList.front();
 	EXPECT_EQ(externalConnectionSettings.protocolType, bacu::EnumUtils::stringToProtocolType(endpoint.protocol_type));
 	EXPECT_EQ(externalConnectionSettings.serverIp, endpoint.server_ip);
 	EXPECT_EQ(externalConnectionSettings.port, endpoint.port);
@@ -49,7 +49,7 @@ TEST_F(SettingsParserTests, CmdOptionsPriority){
 	EXPECT_TRUE(result);
 
 	auto settings = settingsParser.getSettings();
-	EXPECT_EQ(settings->port, 2000);
+	EXPECT_EQ(settings.port, 2000);
 }
 
 
@@ -183,7 +183,7 @@ TEST_F(SettingsParserTests, InvalidProtocol){
 	config.external_connection.endpoint.protocol_type = "INVALID";
 	auto result = parseConfig(config);
 	EXPECT_TRUE(result);
-	EXPECT_TRUE(settingsParser.getSettings()->externalConnectionSettingsList.empty());
+	EXPECT_TRUE(settingsParser.getSettings().externalConnectionSettingsList.empty());
 }
 
 /**

--- a/test/source/StatusAggregatorTests.cpp
+++ b/test/source/StatusAggregatorTests.cpp
@@ -42,10 +42,10 @@ void StatusAggregatorTests::remove_device_from_status_aggregator(){
 }
 
 void StatusAggregatorTests::SetUp(){
-	context_ = std::make_shared<structures::GlobalContext>();
+	context_ = std::make_unique<structures::GlobalContext>(bringauto::settings::Settings{});
 	libHandler_ = std::make_shared<modules::ModuleManagerLibraryHandlerLocal>();
 	libHandler_->loadLibrary(PATH_TO_MODULE);
-	statusAggregator_ = std::make_unique<modules::StatusAggregator>(context_, libHandler_);
+	statusAggregator_ = std::make_unique<modules::StatusAggregator>(*context_, libHandler_);
 	statusAggregator_->init_status_aggregator();
 }
 
@@ -54,7 +54,7 @@ void StatusAggregatorTests::TearDown(){
 }
 
 TEST_F(StatusAggregatorTests, init_status_aggregator_ok) {
-	modules::StatusAggregator statusAggregatorTest {};
+	modules::StatusAggregator statusAggregatorTest { *context_, libHandler_ };
 	int ret = statusAggregatorTest.init_status_aggregator();
 	EXPECT_TRUE(ret == OK);
 	statusAggregatorTest.destroy_status_aggregator();
@@ -66,7 +66,7 @@ TEST_F(StatusAggregatorTests, init_status_aggregator_bad_path) {
 }
 
 TEST_F(StatusAggregatorTests, destroy_status_aggregator_ok) {
-	modules::StatusAggregator statusAggregatorTest {};
+	modules::StatusAggregator statusAggregatorTest { *context_, libHandler_ };
 	int ret = statusAggregatorTest.init_status_aggregator();
 	EXPECT_TRUE(ret == OK);
 	ret = statusAggregatorTest.destroy_status_aggregator();

--- a/test/source/testing_utils/CommunicationMock.cpp
+++ b/test/source/testing_utils/CommunicationMock.cpp
@@ -34,8 +34,8 @@ bool CommunicationMock::sendMessage(ExternalProtocol::ExternalClient* message) {
 	}
 }
 
-std::shared_ptr<ExternalProtocol::ExternalServer> CommunicationMock::receiveMessage() {
-	auto ptr = std::make_shared<ExternalProtocol::ExternalServer>();
+std::unique_ptr<ExternalProtocol::ExternalServer> CommunicationMock::receiveMessage() {
+	auto ptr = std::make_unique<ExternalProtocol::ExternalServer>();
 
 	switch (nextMessageType_) {
 		case CONNECT_RESPONSE:

--- a/test/source/testing_utils/InternalClientForTesting.cpp
+++ b/test/source/testing_utils/InternalClientForTesting.cpp
@@ -9,9 +9,9 @@ namespace testing_utils {
 
 void ClientForTesting::connectSocket() {
 	boost::system::error_code er {};
-	boost::asio::ip::tcp::resolver resolver(context->ioContext);
-	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), context->settings.port);
-	socket = std::make_shared<boost::asio::ip::tcp::socket>(context->ioContext);
+	boost::asio::ip::tcp::resolver resolver(context.ioContext);
+	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), context.settings.port);
+	socket = std::make_shared<boost::asio::ip::tcp::socket>(context.ioContext);
 	socket->connect(endpoint, er);
 	ASSERT_FALSE(er);
 }

--- a/test/source/testing_utils/InternalClientForTesting.cpp
+++ b/test/source/testing_utils/InternalClientForTesting.cpp
@@ -10,7 +10,7 @@ namespace testing_utils {
 void ClientForTesting::connectSocket() {
 	boost::system::error_code er {};
 	boost::asio::ip::tcp::resolver resolver(context->ioContext);
-	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), context->settings->port);
+	boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::tcp::v4(), context->settings.port);
 	socket = std::make_shared<boost::asio::ip::tcp::socket>(context->ioContext);
 	socket->connect(endpoint, er);
 	ASSERT_FALSE(er);

--- a/test/source/testing_utils/ModuleHandlerForTesting.cpp
+++ b/test/source/testing_utils/ModuleHandlerForTesting.cpp
@@ -9,7 +9,7 @@ namespace structures = bringauto::structures;
 
 void ModuleHandlerForTesting::start() {
 	size_t messageCounter { 0 };
-	while(!context->ioContext.stopped()) {
+	while(!context.ioContext.stopped()) {
 		if(!fromInternalQueue_->waitForValueWithTimeout(queue_timeout_length)) {
 			if(fromInternalQueue_->front().disconnected()){
 				fromInternalQueue_->pop();
@@ -41,7 +41,7 @@ void ModuleHandlerForTesting::start() {
 
 void ModuleHandlerForTesting::startWithTimeout(bool onConnect, size_t timeoutNumber) {
 	size_t messageCounter { 0 };
-	while(!context->ioContext.stopped()) {
+	while(!context.ioContext.stopped()) {
 		if(!fromInternalQueue_->waitForValueWithTimeout(queue_timeout_length)) {
 			if(fromInternalQueue_->front().disconnected()){
 				fromInternalQueue_->pop();

--- a/test/source/testing_utils/ModuleHandlerForTesting.cpp
+++ b/test/source/testing_utils/ModuleHandlerForTesting.cpp
@@ -10,20 +10,20 @@ namespace structures = bringauto::structures;
 void ModuleHandlerForTesting::start() {
 	size_t messageCounter { 0 };
 	while(!context.ioContext.stopped()) {
-		if(!fromInternalQueue_->waitForValueWithTimeout(queue_timeout_length)) {
-			if(fromInternalQueue_->front().disconnected()){
-				fromInternalQueue_->pop();
+		if(!fromInternalQueue_.waitForValueWithTimeout(queue_timeout_length)) {
+			if(fromInternalQueue_.front().disconnected()){
+				fromInternalQueue_.pop();
 				continue;
 			}
-			auto message = fromInternalQueue_->front().getMessage();
-			fromInternalQueue_->pop();
+			auto message = fromInternalQueue_.front().getMessage();
+			fromInternalQueue_.pop();
 			if(message.has_deviceconnect()) {
 				auto res = ProtobufUtils::CreateServerMessage(
 					message.deviceconnect().device(),
 					InternalProtocol::DeviceConnectResponse_ResponseType_OK
 				);
 				auto resModuleHandlerMessage = structures::ModuleHandlerMessage(false, res);
-				toInternalQueue_->pushAndNotify(resModuleHandlerMessage);
+				toInternalQueue_.pushAndNotify(resModuleHandlerMessage);
 			}
 			if(message.has_devicestatus()) {
 				auto com = ProtobufUtils::CreateServerMessage(
@@ -31,7 +31,7 @@ void ModuleHandlerForTesting::start() {
 					message.devicestatus().statusdata()
 				);
 				auto comModuleHandlerMessage = structures::ModuleHandlerMessage(false, com);
-				toInternalQueue_->pushAndNotify(comModuleHandlerMessage);
+				toInternalQueue_.pushAndNotify(comModuleHandlerMessage);
 			}
 			++messageCounter;
 		}
@@ -42,13 +42,13 @@ void ModuleHandlerForTesting::start() {
 void ModuleHandlerForTesting::startWithTimeout(bool onConnect, size_t timeoutNumber) {
 	size_t messageCounter { 0 };
 	while(!context.ioContext.stopped()) {
-		if(!fromInternalQueue_->waitForValueWithTimeout(queue_timeout_length)) {
-			if(fromInternalQueue_->front().disconnected()){
-				fromInternalQueue_->pop();
+		if(!fromInternalQueue_.waitForValueWithTimeout(queue_timeout_length)) {
+			if(fromInternalQueue_.front().disconnected()){
+				fromInternalQueue_.pop();
 				continue;
 			}
-			auto message = fromInternalQueue_->front().getMessage();
-			fromInternalQueue_->pop();
+			auto message = fromInternalQueue_.front().getMessage();
+			fromInternalQueue_.pop();
 			if(message.has_deviceconnect()) {
 				if(onConnect && timeoutNumber > 0) {
 					--timeoutNumber;
@@ -59,7 +59,7 @@ void ModuleHandlerForTesting::startWithTimeout(bool onConnect, size_t timeoutNum
 					InternalProtocol::DeviceConnectResponse_ResponseType_OK
 				);
 				auto resModuleHandlerMessage = structures::ModuleHandlerMessage(false, res);
-				toInternalQueue_->pushAndNotify(resModuleHandlerMessage);
+				toInternalQueue_.pushAndNotify(resModuleHandlerMessage);
 			}
 			if(message.has_devicestatus()) {
 				if(!onConnect && timeoutNumber > 0) {
@@ -71,7 +71,7 @@ void ModuleHandlerForTesting::startWithTimeout(bool onConnect, size_t timeoutNum
 					message.devicestatus().statusdata()
 				);
 				auto comModuleHandlerMessage = structures::ModuleHandlerMessage(false, com);
-				toInternalQueue_->pushAndNotify(comModuleHandlerMessage);
+				toInternalQueue_.pushAndNotify(comModuleHandlerMessage);
 			}
 			++messageCounter;
 		}

--- a/test/source/testing_utils/TestHandler.cpp
+++ b/test/source/testing_utils/TestHandler.cpp
@@ -17,8 +17,6 @@ namespace structures = bringauto::structures;
 TestHandler::TestHandler(const std::vector <InternalProtocol::Device> &devices, const std::vector <std::string> &data) {
 	settings = {.port = port};
 
-	toInternalQueue = std::make_shared < structures::AtomicQueue < structures::ModuleHandlerMessage >> ();
-	fromInternalQueue = std::make_shared < structures::AtomicQueue < structures::InternalClientMessage >> ();
 	for(size_t i = 0; i < devices.size(); ++i) {
 		connects.push_back(ProtobufUtils::CreateClientMessage(devices[i]));
 		statuses.push_back(ProtobufUtils::CreateClientMessage(devices[i], data[i]));
@@ -48,8 +46,6 @@ TestHandler::TestHandler(
 		const std::vector <std::string> &data) {
 	settings = {.port = port};
 
-	toInternalQueue = std::make_shared < structures::AtomicQueue < structures::ModuleHandlerMessage >> ();
-	fromInternalQueue = std::make_shared < structures::AtomicQueue < structures::InternalClientMessage >> ();
 	for(size_t i = 0; i < devices.size(); ++i) {
 		connects.push_back(ProtobufUtils::CreateClientMessage(devices[i]));
 		statuses.push_back(ProtobufUtils::CreateClientMessage(devices[i], data[i]));

--- a/test/source/testing_utils/TestHandler.cpp
+++ b/test/source/testing_utils/TestHandler.cpp
@@ -127,7 +127,6 @@ void TestHandler::runTestsParallelConnections() {
 	if(!context.ioContext.stopped()) {
 		context.ioContext.stop();
 	}
-	internalServer.destroy();
 }
 
 void TestHandler::runConnects() {
@@ -197,7 +196,6 @@ void TestHandler::runTestsSerialConnections() {
 	if(!context.ioContext.stopped()) {
 		context.ioContext.stop();
 	}
-	internalServer.destroy();
 }
 
 void TestHandler::runConnects(size_t index, size_t header, std::string data, bool recastHeader) {
@@ -284,7 +282,6 @@ void TestHandler::runTestsWithWrongMessage(size_t index, uint32_t header, std::s
 	if(!context.ioContext.stopped()) {
 		context.ioContext.stop();
 	}
-	internalServer.destroy();
 }
 
 void TestHandler::runConnects(size_t numberOfErrors) {
@@ -372,7 +369,6 @@ void TestHandler::runTestsWithModuleHandlerTimeout(bool onConnect, size_t timeou
 	if(!context.ioContext.stopped()) {
 		context.ioContext.stop();
 	}
-	internalServer.destroy();
 }
 
 

--- a/test/source/testing_utils/TestHandler.cpp
+++ b/test/source/testing_utils/TestHandler.cpp
@@ -28,8 +28,8 @@ TestHandler::TestHandler(const std::vector <InternalProtocol::Device> &devices, 
 			InternalProtocol::DeviceConnectResponse_ResponseType_OK
 		));
 
-		contexts.push_back(std::make_shared<structures::GlobalContext>(settings::Settings{.port = port}));
-		clients.emplace_back(contexts[i]);
+		contexts.push_back(std::make_unique<structures::GlobalContext>(settings::Settings{.port = port}));
+		clients.emplace_back(*contexts[i]);
 		expectedMessageNumber += numberOfMessages;
 		for(size_t y = 0; y < i; ++y) {
 			auto a = std::make_shared<structures::DeviceIdentification>(devices[y]);
@@ -56,8 +56,8 @@ TestHandler::TestHandler(
 		commands.push_back(ProtobufUtils::CreateServerMessage(devices[i], data[i]));
 		responses.push_back(ProtobufUtils::CreateServerMessage(devices[i], responseTypes[i]));
 
-		contexts.push_back(std::make_shared<structures::GlobalContext>(settings::Settings{.port = port}));
-		clients.emplace_back(contexts[i]);
+		contexts.push_back(std::make_unique<structures::GlobalContext>(settings::Settings{.port = port}));
+		clients.emplace_back(*contexts[i]);
 		if(responseTypes[i] == InternalProtocol::DeviceConnectResponse_ResponseType_OK) {
 			expectedMessageNumber += numberOfMessages;
 			for(size_t y = 0; y < i; ++y) {
@@ -106,17 +106,17 @@ void TestHandler::ParallelRun(size_t index) {
 }
 
 void TestHandler::runTestsParallelConnections() {
-	auto context = std::make_shared<structures::GlobalContext>(settings);
+	structures::GlobalContext context { settings };
 
-	boost::asio::signal_set signals(context->ioContext, SIGINT, SIGTERM);
-	signals.async_wait([context](auto, auto) { context->ioContext.stop(); });
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
 	internal_server::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
 	testing_utils::ModuleHandlerForTesting moduleHandler(context, fromInternalQueue, toInternalQueue,
 		expectedMessageNumber);
 
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.start(); });
-	std::jthread contextThread([&context]() { context->ioContext.run(); });
+	std::jthread contextThread([&context]() { context.ioContext.run(); });
 	internalServer.run();
 
 	std::vector <std::jthread> clientThreads {};
@@ -128,8 +128,8 @@ void TestHandler::runTestsParallelConnections() {
 		clientThreads[i].join();
 	}
 
-	if(!context->ioContext.stopped()) {
-		context->ioContext.stop();
+	if(!context.ioContext.stopped()) {
+		context.ioContext.stop();
 	}
 	internalServer.destroy();
 }
@@ -182,10 +182,10 @@ void TestHandler::serialRun() {
 }
 
 void TestHandler::runTestsSerialConnections() {
-	auto context = std::make_shared<structures::GlobalContext>(settings);
+	structures::GlobalContext context { settings };
 
-	boost::asio::signal_set signals(context->ioContext, SIGINT, SIGTERM);
-	signals.async_wait([context](auto, auto) { context->ioContext.stop(); });
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
 	internal_server::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
 
@@ -193,13 +193,13 @@ void TestHandler::runTestsSerialConnections() {
 		expectedMessageNumber);
 
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.start(); });
-	std::jthread contextThread([&context]() { context->ioContext.run(); });
+	std::jthread contextThread([&context]() { context.ioContext.run(); });
 	internalServer.run();
 
 	serialRun();
 
-	if(!context->ioContext.stopped()) {
-		context->ioContext.stop();
+	if(!context.ioContext.stopped()) {
+		context.ioContext.stop();
 	}
 	internalServer.destroy();
 }
@@ -264,10 +264,10 @@ void TestHandler::serialRunWithExpectedError(size_t index, size_t header, std::s
 
 void TestHandler::runTestsWithWrongMessage(size_t index, uint32_t header, std::string data, bool onConnect,
 		bool recastHeader) {
-	auto context = std::make_shared<structures::GlobalContext>(settings);
+	structures::GlobalContext context { settings };
 
-	boost::asio::signal_set signals(context->ioContext, SIGINT, SIGTERM);
-	signals.async_wait([context](auto, auto) { context->ioContext.stop(); });
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
 	internal_server::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
 
@@ -280,13 +280,13 @@ void TestHandler::runTestsWithWrongMessage(size_t index, uint32_t header, std::s
 		expectedMessageNumber);
 
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.start(); });
-	std::jthread contextThread([&context]() { context->ioContext.run(); });
+	std::jthread contextThread([&context]() { context.ioContext.run(); });
 	internalServer.run();
 
 	serialRunWithExpectedError(index, header, data, onConnect, recastHeader);
 
-	if(!context->ioContext.stopped()) {
-		context->ioContext.stop();
+	if(!context.ioContext.stopped()) {
+		context.ioContext.stop();
 	}
 	internalServer.destroy();
 }
@@ -349,10 +349,10 @@ void TestHandler::serialRunWithExpectedError(bool onConnect, size_t numberOfErro
 }
 
 void TestHandler::runTestsWithModuleHandlerTimeout(bool onConnect, size_t timeoutNumber) {
-	auto context = std::make_shared<structures::GlobalContext>(settings);
+	structures::GlobalContext context { settings };
 
-	boost::asio::signal_set signals(context->ioContext, SIGINT, SIGTERM);
-	signals.async_wait([context](auto, auto) { context->ioContext.stop(); });
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
 
 	internal_server::InternalServer internalServer { context, fromInternalQueue, toInternalQueue };
 
@@ -367,14 +367,14 @@ void TestHandler::runTestsWithModuleHandlerTimeout(bool onConnect, size_t timeou
 	std::jthread moduleHandlerThread([&moduleHandler, onConnect, timeoutNumber]() {
 		moduleHandler.startWithTimeout(onConnect, timeoutNumber);
 	});
-	std::jthread contextThread([&context]() { context->ioContext.run(); });
+	std::jthread contextThread([&context]() { context.ioContext.run(); });
 	internalServer.run();
 
 	serialRunWithExpectedError(onConnect, timeoutNumber);
 
 
-	if(!context->ioContext.stopped()) {
-		context->ioContext.stop();
+	if(!context.ioContext.stopped()) {
+		context.ioContext.stop();
 	}
 	internalServer.destroy();
 }

--- a/test/source/testing_utils/TestHandler.cpp
+++ b/test/source/testing_utils/TestHandler.cpp
@@ -15,8 +15,7 @@ namespace structures = bringauto::structures;
 
 
 TestHandler::TestHandler(const std::vector <InternalProtocol::Device> &devices, const std::vector <std::string> &data) {
-	settings = std::make_shared<settings::Settings>();
-	settings->port = port;
+	settings = {.port = port};
 
 	toInternalQueue = std::make_shared < structures::AtomicQueue < structures::ModuleHandlerMessage >> ();
 	fromInternalQueue = std::make_shared < structures::AtomicQueue < structures::InternalClientMessage >> ();
@@ -29,9 +28,7 @@ TestHandler::TestHandler(const std::vector <InternalProtocol::Device> &devices, 
 			InternalProtocol::DeviceConnectResponse_ResponseType_OK
 		));
 
-		contexts.push_back(std::make_shared<structures::GlobalContext>());
-		contexts[i]->settings = std::make_shared<settings::Settings>();
-		contexts[i]->settings->port = (port);
+		contexts.push_back(std::make_shared<structures::GlobalContext>(settings::Settings{.port = port}));
 		clients.emplace_back(contexts[i]);
 		expectedMessageNumber += numberOfMessages;
 		for(size_t y = 0; y < i; ++y) {
@@ -49,8 +46,7 @@ TestHandler::TestHandler(
 		const std::vector <InternalProtocol::Device> &devices,
 		const std::vector <InternalProtocol::DeviceConnectResponse_ResponseType> &responseTypes,
 		const std::vector <std::string> &data) {
-	settings = std::make_shared<settings::Settings>();
-	settings->port = port;
+	settings = {.port = port};
 
 	toInternalQueue = std::make_shared < structures::AtomicQueue < structures::ModuleHandlerMessage >> ();
 	fromInternalQueue = std::make_shared < structures::AtomicQueue < structures::InternalClientMessage >> ();
@@ -60,9 +56,7 @@ TestHandler::TestHandler(
 		commands.push_back(ProtobufUtils::CreateServerMessage(devices[i], data[i]));
 		responses.push_back(ProtobufUtils::CreateServerMessage(devices[i], responseTypes[i]));
 
-		contexts.push_back(std::make_shared<structures::GlobalContext>());
-		contexts[i]->settings = std::make_shared<settings::Settings>();
-		contexts[i]->settings->port = (port);
+		contexts.push_back(std::make_shared<structures::GlobalContext>(settings::Settings{.port = port}));
 		clients.emplace_back(contexts[i]);
 		if(responseTypes[i] == InternalProtocol::DeviceConnectResponse_ResponseType_OK) {
 			expectedMessageNumber += numberOfMessages;
@@ -126,6 +120,7 @@ void TestHandler::runTestsParallelConnections() {
 	internalServer.run();
 
 	std::vector <std::jthread> clientThreads {};
+	clientThreads.reserve(responses.size());
 	for(size_t i = 0; i < responses.size(); ++i) {
 		clientThreads.emplace_back([this, i]() { (ParallelRun(i)); });
 	}
@@ -175,8 +170,8 @@ void TestHandler::runStatuses() {
 }
 
 void TestHandler::disconnectAll() {
-	for(size_t i = 0; i < clients.size(); ++i) {
-		clients[i].disconnectSocket();
+	for(auto & client : clients) {
+		client.disconnectSocket();
 	}
 }
 

--- a/test/source/testing_utils/TestHandler.cpp
+++ b/test/source/testing_utils/TestHandler.cpp
@@ -30,9 +30,9 @@ TestHandler::TestHandler(const std::vector <InternalProtocol::Device> &devices, 
 		clients.emplace_back(*contexts[i]);
 		expectedMessageNumber += numberOfMessages;
 		for(size_t y = 0; y < i; ++y) {
-			auto a = std::make_shared<structures::DeviceIdentification>(devices[y]);
-			auto b = std::make_shared<structures::DeviceIdentification>(devices[i]);
-			if(a->isSame(b)) {
+			const structures::DeviceIdentification a { devices[y] };
+			const structures::DeviceIdentification b { devices[i] };
+			if(a.isSame(b)) {
 				expectedMessageNumber -= (numberOfMessages - 1);
 				break;
 			}
@@ -57,9 +57,9 @@ TestHandler::TestHandler(
 		if(responseTypes[i] == InternalProtocol::DeviceConnectResponse_ResponseType_OK) {
 			expectedMessageNumber += numberOfMessages;
 			for(size_t y = 0; y < i; ++y) {
-				auto a = std::make_shared<structures::DeviceIdentification>(devices[y]);
-				auto b = std::make_shared<structures::DeviceIdentification>(devices[i]);
-				if(a->isSame(b)) {
+				const structures::DeviceIdentification a { devices[y] };
+				const structures::DeviceIdentification b { devices[i] };
+				if(a.isSame(b)) {
 					expectedMessageNumber -= (numberOfMessages - 1);
 					break;
 				}
@@ -141,11 +141,9 @@ void TestHandler::runConnects() {
 			clients[i].disconnectSocket();
 		} else {
 			for(size_t y = 0; y < i; ++y) {
-				auto a = std::make_shared<structures::DeviceIdentification>(
-					connects[y].deviceconnect().device());
-				auto b = std::make_shared<structures::DeviceIdentification>(
-					connects[i].deviceconnect().device());
-				if(a->isSame(b)) {
+				const structures::DeviceIdentification a { connects[y].deviceconnect().device() };
+				const structures::DeviceIdentification b { connects[i].deviceconnect().device() };
+				if(a.isSame(b)) {
 					clients[y].disconnectSocket();
 				}
 			}
@@ -216,11 +214,9 @@ void TestHandler::runConnects(size_t index, size_t header, std::string data, boo
 				clients[i].disconnectSocket();
 			} else {
 				for(size_t y = 0; y < i; ++y) {
-					auto a = std::make_shared<structures::DeviceIdentification>(
-						connects[y].deviceconnect().device());
-					auto b = std::make_shared<structures::DeviceIdentification>(
-						connects[i].deviceconnect().device());
-					if(a->isSame(b)) {
+					const structures::DeviceIdentification a { connects[y].deviceconnect().device() };
+					const structures::DeviceIdentification b { connects[i].deviceconnect().device() };
+					if(a.isSame(b)) {
 						clients[y].disconnectSocket();
 					}
 				}
@@ -302,11 +298,9 @@ void TestHandler::runConnects(size_t numberOfErrors) {
 				clients[i].disconnectSocket();
 			} else {
 				for(size_t y = 0; y < i; ++y) {
-					auto a = std::make_shared<structures::DeviceIdentification>(
-						connects[y].deviceconnect().device());
-					auto b = std::make_shared<structures::DeviceIdentification>(
-						connects[i].deviceconnect().device());
-					if(a->isSame(b)) {
+					const structures::DeviceIdentification a { connects[y].deviceconnect().device() };
+					const structures::DeviceIdentification b { connects[i].deviceconnect().device() };
+					if(a.isSame(b)) {
 						clients[y].disconnectSocket();
 					}
 				}


### PR DESCRIPTION
Replaces `shared_ptr` usage across the Module Gateway with value/reference (and `optional`) semantics, and swaps explicit `destroy()` methods for RAII destructors.

- `Settings`: value semantics in `GlobalContext` and `SettingsParser`
- `GlobalContext`: passed by value/reference instead of `shared_ptr`
- `AtomicQueue`: value/reference semantics throughout
- `DeviceIdentification`: value/`optional` instead of `shared_ptr`
- `commandForwardingQueue`: reference instead of `shared_ptr<AtomicQueue>`
- Component teardown: explicit `destroy()` replaced with RAII destructors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated component interfaces to use direct references and value-based configuration.
  * Removed explicit shutdown methods; cleanup now occurs automatically when components are released.
  * Message reception now transfers exclusive ownership of received messages.
  * Connection device identification is represented as an optional value.
  * Settings are accessed directly rather than through shared pointers.
* **Bug Fixes**
  * Improved disconnect-message handling during connection and reconnection workflows.
* **Tests**
  * Updated test coverage for revised lifecycle, ownership, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->