### PR TITLE
Interruptible AtomicQueue for prompt graceful shutdown on SIGTERM

### DIFF
--- a/include/bringauto/external_client/ExternalClient.hpp
+++ b/include/bringauto/external_client/ExternalClient.hpp
@@ -34,6 +34,11 @@ public:
 	 */
 	void run();
 
+	/**
+	 * @brief Interrupt the internal queues so blocked waits wake up immediately on shutdown
+	 */
+	void requestStop();
+
 private:
 
 	/**

--- a/include/bringauto/structures/AtomicQueue.hpp
+++ b/include/bringauto/structures/AtomicQueue.hpp
@@ -30,14 +30,25 @@ public:
 	}
 
 	/**
-	 * @brief Waits for timeout or till being notified that queue is not empty.
+	 * @brief Waits for timeout or till being notified that queue is not empty
+	 * or that the queue has been interrupted.
 	 * @param timeout length of timeout
 	 * @return true if the queue is empty
 	 */
 	bool waitForValueWithTimeout(const std::chrono::seconds &timeout) {
 		std::unique_lock<std::mutex> lock(mtx_);
-		cv_.wait_for(lock, timeout, [this]() { return !queue_.empty(); });
+		cv_.wait_for(lock, timeout, [this]() { return !queue_.empty() || interrupted_; });
 		return queue_.empty();
+	}
+
+	/**
+	 * @brief Wakes all threads blocked in waitForValueWithTimeout() immediately and keeps
+	 * every subsequent wait from blocking. Used to unblock waiters during shutdown.
+	 */
+	void interrupt() {
+		std::lock_guard<std::mutex> lock(mtx_);
+		interrupted_ = true;
+		cv_.notify_all();
 	}
 
 	/**
@@ -88,6 +99,7 @@ private:
 	std::queue<T> queue_ {};
 	std::mutex mtx_ {};
 	std::condition_variable cv_ {};
+	bool interrupted_ { false };
 };
 
 }

--- a/main.cpp
+++ b/main.cpp
@@ -74,9 +74,6 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
-	signals.async_wait([&context](auto, auto) { context.ioContext.stop(); });
-
 	bas::AtomicQueue<bas::ModuleHandlerMessage> toInternalQueue;
 	bas::AtomicQueue<bas::InternalClientMessage> fromInternalQueue;
 	bas::AtomicQueue<bas::InternalClientMessage> commandForwardingQueue;
@@ -87,6 +84,19 @@ int main(int argc, char **argv) {
 													  commandForwardingQueue, toInternalQueue, toExternalQueue };
 	bringauto::external_client::ExternalClient externalClient { context, moduleLibrary, toExternalQueue, commandForwardingQueue };
 
+	// Stop the io_context and wake every queue wait so all worker threads exit promptly
+	auto requestShutdown = [&]() {
+		context.ioContext.stop();
+		toInternalQueue.interrupt();
+		fromInternalQueue.interrupt();
+		commandForwardingQueue.interrupt();
+		toExternalQueue.interrupt();
+		externalClient.requestStop();
+	};
+
+	boost::asio::signal_set signals(context.ioContext, SIGINT, SIGTERM);
+	signals.async_wait([&](auto, auto) { requestShutdown(); });
+
 	std::jthread moduleHandlerThread([&moduleHandler]() { moduleHandler.run(); });
 	std::jthread externalClientThread([&externalClient]() { externalClient.run(); });
 	std::jthread contextThread2([&context]() { context.ioContext.run(); });
@@ -95,7 +105,7 @@ int main(int argc, char **argv) {
 		internalServer.run();
 	} catch(boost::system::system_error &e) {
 		baset::Logger::logError("Error during run {}", e.what());
-		context.ioContext.stop();
+		requestShutdown();
 	}
 
 	contextThread2.join();

--- a/source/bringauto/external_client/ExternalClient.cpp
+++ b/source/bringauto/external_client/ExternalClient.cpp
@@ -89,6 +89,11 @@ ExternalClient::~ExternalClient() {
 	settings::Logger::logInfo("External client stopped");
 }
 
+void ExternalClient::requestStop() {
+	reconnectQueue_.interrupt();
+	fromExternalQueue_.interrupt();
+}
+
 void ExternalClient::run() {
 	settings::Logger::logInfo("External client started, constants used: reconnect_delay: {}, queue_timeout_length: {}, "
 				 "immediate_disconnect_timeout: {}, status_response_timeout: {}",


### PR DESCRIPTION
Makes the Module Gateway shut down promptly on SIGTERM instead of being force-killed.

`ExternalClient::handleAggregatedMessages` could block up to `immediate_disconnect_timeout` (10s) in `reconnectQueue_.waitForValueWithTimeout()` after a failed send, because the wait predicate ignored shutdown. If SIGTERM arrived during that window, the process exceeded the termination grace period and was SIGKILLed — surfaced by the C++ ES network-disruption scenario (ts_250).

- `AtomicQueue::interrupt()` sets a flag and wakes all waiters; the wait predicate now returns on value-available **or** interrupt.
- `ExternalClient::requestStop()` interrupts its internal queues.
- `main` gains `requestShutdown()` (stop io_context + interrupt all queues + `externalClient.requestStop()`), called from both the SIGINT/SIGTERM handler and the `internalServer.run()` error path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling for interrupts and runtime errors.
  * Background operations and queued requests now stop promptly instead of remaining blocked until timeout.
  * Standardized shutdown behavior across signal-triggered and error-triggered exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->